### PR TITLE
fix: load more on collections appends client-side

### DIFF
--- a/apps/web/src/app/api/collections/[handle]/products/route.ts
+++ b/apps/web/src/app/api/collections/[handle]/products/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { storefrontQuery } from "@/lib/shopify/client";
+import { COLLECTION_QUERY } from "@/lib/shopify/queries";
+import type { CollectionQueryResponse } from "@/lib/shopify/types";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ handle: string }> }
+) {
+  const { handle } = await params;
+  const sp = request.nextUrl.searchParams;
+
+  const after = sp.get("after");
+  const sort = sp.get("sort") ?? "COLLECTION_DEFAULT";
+  const reverse = sp.get("reverse") === "true";
+  const first = Number(sp.get("first") ?? 12);
+
+  const result = await storefrontQuery<CollectionQueryResponse>(
+    COLLECTION_QUERY,
+    {
+      variables: { handle, first, after, sortKey: sort, reverse },
+    }
+  );
+
+  if (!result.ok || !result.data.collection) {
+    return NextResponse.json(
+      { error: "Failed to fetch products" },
+      { status: 500 }
+    );
+  }
+
+  const { products } = result.data.collection;
+
+  return NextResponse.json({
+    products: products.edges.map((e) => e.node),
+    pageInfo: products.pageInfo,
+  });
+}

--- a/apps/web/src/app/collections/[handle]/page.tsx
+++ b/apps/web/src/app/collections/[handle]/page.tsx
@@ -7,8 +7,7 @@ import {
 import { notFound } from "next/navigation";
 
 import { CollectionModuleRenderer } from "@/components/collection/collection-module";
-import { CollectionPagination } from "@/components/collection/collection-pagination";
-import { ProductGrid } from "@/components/collection/product-grid";
+import { CollectionProducts } from "@/components/collection/collection-products";
 import { SortSelector } from "@/components/collection/sort-selector";
 import { parseSortParams } from "@/components/collection/sort-utils";
 import { getSEOMetadata } from "@/lib/seo";
@@ -52,7 +51,7 @@ export default async function CollectionPage({
 }: PageProps) {
   const { handle } = await params;
   const sp = await searchParams;
-  const { sort, reverse, after } = parseSortParams(sp);
+  const { sort, reverse } = parseSortParams(sp);
 
   const [{ data: sanityCollection }, shopifyResult] = await Promise.all([
     sanityFetch({
@@ -60,7 +59,7 @@ export default async function CollectionPage({
       params: { handle },
     }),
     storefrontQuery<CollectionQueryResponse>(COLLECTION_QUERY, {
-      variables: { handle, first: 12, after, sortKey: sort, reverse },
+      variables: { handle, first: 12, after: null, sortKey: sort, reverse },
     }),
   ]);
 
@@ -94,11 +93,14 @@ export default async function CollectionPage({
         <SortSelector currentReverse={reverse} currentSort={sort} />
       </div>
 
-      <ProductGrid products={products} />
-
-      {shopifyCollection.products.pageInfo && (
-        <CollectionPagination pageInfo={shopifyCollection.products.pageInfo} />
-      )}
+      <CollectionProducts
+        handle={handle}
+        initialPageInfo={shopifyCollection.products.pageInfo}
+        initialProducts={products}
+        key={`${sort}-${reverse}`}
+        reverse={reverse}
+        sort={sort}
+      />
 
       {sanityCollection.modules && sanityCollection.modules.length > 0 && (
         <div className="mt-12">

--- a/apps/web/src/components/collection/collection-pagination.tsx
+++ b/apps/web/src/components/collection/collection-pagination.tsx
@@ -1,33 +1,37 @@
 "use client";
 
 import { Button } from "@workspace/ui/components/button";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback } from "react";
+import { Loader2 } from "lucide-react";
 
 type CollectionPaginationProps = {
-  pageInfo: {
-    hasNextPage: boolean;
-    endCursor: string | null;
-  };
+  hasNextPage: boolean;
+  isLoading: boolean;
+  onLoadMore: () => void;
 };
 
-export function CollectionPagination({ pageInfo }: CollectionPaginationProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const loadMore = useCallback(() => {
-    if (!pageInfo.endCursor) return;
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("after", pageInfo.endCursor);
-    router.push(`?${params.toString()}`);
-  }, [pageInfo.endCursor, router, searchParams]);
-
-  if (!pageInfo.hasNextPage) return null;
+export function CollectionPagination({
+  hasNextPage,
+  isLoading,
+  onLoadMore,
+}: CollectionPaginationProps) {
+  if (!hasNextPage) return null;
 
   return (
     <div className="mt-8 flex justify-center">
-      <Button onClick={loadMore} size="lg" variant="outline">
-        Load More
+      <Button
+        disabled={isLoading}
+        onClick={onLoadMore}
+        size="lg"
+        variant="outline"
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="mr-2 size-4 animate-spin" />
+            Loading...
+          </>
+        ) : (
+          "Load More"
+        )}
       </Button>
     </div>
   );

--- a/apps/web/src/components/collection/collection-products.tsx
+++ b/apps/web/src/components/collection/collection-products.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { CollectionPagination } from "@/components/collection/collection-pagination";
+import { ProductGrid } from "@/components/collection/product-grid";
+import type { ShopifyCollectionProduct } from "@/lib/shopify/types";
+
+type PageInfo = {
+  hasNextPage: boolean;
+  endCursor: string | null;
+};
+
+type CollectionProductsProps = {
+  handle: string;
+  initialPageInfo: PageInfo;
+  initialProducts: ShopifyCollectionProduct[];
+  reverse: boolean;
+  sort: string;
+};
+
+export function CollectionProducts({
+  handle,
+  initialPageInfo,
+  initialProducts,
+  reverse,
+  sort,
+}: CollectionProductsProps) {
+  const [products, setProducts] =
+    useState<ShopifyCollectionProduct[]>(initialProducts);
+  const [pageInfo, setPageInfo] = useState<PageInfo>(initialPageInfo);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadMore = useCallback(async () => {
+    if (!pageInfo.endCursor || isLoading) return;
+
+    setIsLoading(true);
+
+    const params = new URLSearchParams({
+      after: pageInfo.endCursor,
+      sort,
+      reverse: String(reverse),
+    });
+
+    try {
+      const res = await fetch(
+        `/api/collections/${handle}/products?${params.toString()}`
+      );
+
+      if (!res.ok) return;
+
+      const data = (await res.json()) as {
+        products: ShopifyCollectionProduct[];
+        pageInfo: PageInfo;
+      };
+
+      setProducts((prev) => [...prev, ...data.products]);
+      setPageInfo(data.pageInfo);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [pageInfo.endCursor, isLoading, sort, reverse, handle]);
+
+  return (
+    <>
+      <ProductGrid products={products} />
+      <CollectionPagination
+        hasNextPage={pageInfo.hasNextPage}
+        isLoading={isLoading}
+        onLoadMore={loadMore}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/collection/sort-utils.ts
+++ b/apps/web/src/components/collection/sort-utils.ts
@@ -2,11 +2,9 @@
 export function parseSortParams(sp: Record<string, string>): {
   sort: string;
   reverse: boolean;
-  after: string | null;
 } {
   return {
     sort: sp.sort ?? "COLLECTION_DEFAULT",
     reverse: sp.reverse === "true",
-    after: sp.after ?? null,
   };
 }


### PR DESCRIPTION
## Summary

- Replaced URL-based pagination (`router.push` with `?after=` param) with client-side state accumulation via an API route
- Products now append in-place on "Load More" — no full page navigation, scroll position preserved
- Sort changes correctly reset the product list to page 1

## Changes

- **New**: `apps/web/src/app/api/collections/[handle]/products/route.ts` — API route proxying Shopify collection products query
- **New**: `apps/web/src/components/collection/collection-products.tsx` — client wrapper managing accumulated products state
- **Modified**: `collection-pagination.tsx` — callback pattern with loading spinner instead of `router.push`
- **Modified**: `sort-utils.ts` — removed `after` param (pagination is now client-side)
- **Modified**: `page.tsx` — wired `CollectionProducts` component with `key` prop for sort reset

## Demo

![Load More Demo](./load-more-fix.gif)

## Test Plan

- [x] `pnpm check-types` passes
- [x] Load More appends products without page reload
- [x] URL stays clean (no `?after=` param)
- [x] Scroll position preserved after loading more
- [x] Sort change resets to first page (12 products)
- [x] Load More button disappears when no more pages
- [x] Loading spinner shows during fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collection products API endpoint to fetch products for a given collection with sorting and pagination support.
  * Introduced a loading indicator in the pagination control that displays while fetching additional products, providing better user feedback during data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->