### PR TITLE
fix: pre-select default variant options on PDP initial load

### DIFF
--- a/apps/web/src/components/product/variant-selector.tsx
+++ b/apps/web/src/components/product/variant-selector.tsx
@@ -36,9 +36,14 @@ export function VariantSelector({
   const router = useRouter();
   const searchParams = useSearchParams();
 
+  const defaultVariant = variants[0];
   const currentSelections: Record<string, string> = {};
   for (const option of options) {
-    currentSelections[option.name] = searchParams.get(option.name) ?? "";
+    const fromUrl = searchParams.get(option.name);
+    const fallback =
+      defaultVariant?.selectedOptions.find((o) => o.name === option.name)
+        ?.value ?? "";
+    currentSelections[option.name] = fromUrl ?? fallback;
   }
 
   const handleSelect = useCallback(


### PR DESCRIPTION
## Summary

- Variant options (size, color, etc.) now pre-select the first variant's values on initial page load
- Previously, options appeared unselected despite a default variant being used for add-to-cart

## What Changed

`variant-selector.tsx` — When no URL search param exists for an option, falls back to `variants[0].selectedOptions` instead of empty string.

## Test Plan

- [x] Navigate to a PDP with variants — options are pre-selected on load
- [x] Selecting a different option still updates URL params and UI
- [x] Add to cart uses the visually selected variant
- [x] `pnpm check-types` passes

Closes ROB-1904