### PR TITLE
feat: link cart items to product page with variant params

### DIFF
--- a/apps/web/src/components/cart/cart-line-item.tsx
+++ b/apps/web/src/components/cart/cart-line-item.tsx
@@ -3,35 +3,59 @@
 import { Button } from "@workspace/ui/components/button";
 import { Minus, Plus, Trash2 } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 
 import { formatMoney } from "@/lib/shopify/money";
 import type { CartLine } from "@/lib/shopify/types";
 import { useCart } from "./cart-context";
 
+function buildProductUrl(line: CartLine): string {
+  const handle = line.merchandise.product.handle;
+  const params = new URLSearchParams();
+  for (const opt of line.merchandise.selectedOptions) {
+    if (opt.value && opt.value !== "Default Title") {
+      params.set(opt.name, opt.value);
+    }
+  }
+  const qs = params.toString();
+  return `/products/${handle}${qs ? `?${qs}` : ""}`;
+}
+
 export function CartLineItem({ line }: { line: CartLine }) {
-  const { updateLine, removeLine } = useCart();
+  const { updateLine, removeLine, closeCart } = useCart();
+  const productUrl = buildProductUrl(line);
 
   return (
     <div className="flex gap-4 py-4">
-      {line.merchandise.image ? (
-        <div className="relative size-20 shrink-0 overflow-hidden rounded-lg border">
-          <Image
-            alt={line.merchandise.image.altText ?? line.merchandise.title}
-            className="object-cover"
-            fill
-            sizes="80px"
-            src={line.merchandise.image.url}
-          />
-        </div>
-      ) : (
-        <div className="size-20 shrink-0 rounded-lg border bg-muted" />
-      )}
+      <Link
+        className="shrink-0"
+        href={productUrl}
+        onClick={closeCart}
+      >
+        {line.merchandise.image ? (
+          <div className="relative size-20 overflow-hidden rounded-lg border">
+            <Image
+              alt={line.merchandise.image.altText ?? line.merchandise.title}
+              className="object-cover"
+              fill
+              sizes="80px"
+              src={line.merchandise.image.url}
+            />
+          </div>
+        ) : (
+          <div className="size-20 rounded-lg border bg-muted" />
+        )}
+      </Link>
 
       <div className="flex flex-1 flex-col justify-between">
         <div>
-          <p className="font-medium text-sm leading-tight">
+          <Link
+            className="font-medium text-sm leading-tight hover:underline"
+            href={productUrl}
+            onClick={closeCart}
+          >
             {line.merchandise.product.title}
-          </p>
+          </Link>
           {line.merchandise.title !== "Default Title" && (
             <p className="mt-0.5 text-muted-foreground text-xs">
               {line.merchandise.title}


### PR DESCRIPTION
## Summary

- Cart drawer product image and title are now clickable links to the PDP
- Links include variant search params (e.g. `/products/t-shirt?Size=M&Color=Black`) so the correct variant is pre-selected
- Clicking a link closes the cart drawer

## What Changed

`cart-line-item.tsx` — Wrapped image and title in `<Link>` elements. Added `buildProductUrl()` helper that constructs the URL from `merchandise.product.handle` + `merchandise.selectedOptions`.

## Test Plan

- [x] Cart item image links to PDP
- [x] Cart item title links to PDP
- [x] Variant params included in URL for multi-variant products
- [x] Single-variant / "Default Title" products link without params
- [x] Cart drawer closes on link click
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes

Closes ROB-1905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Products in the cart can now be clicked to navigate to their dedicated product pages; clicking product images or titles closes the cart and opens the product page.
  * Product titles now display hover styling to indicate interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->