### PR TITLE
fix: enable add-to-cart when default variant is pre-selected

### DIFF
--- a/apps/web/src/app/products/[handle]/page.tsx
+++ b/apps/web/src/app/products/[handle]/page.tsx
@@ -155,14 +155,24 @@ export default async function ProductPage({ params, searchParams }: PageProps) {
   const shopifyProduct = shopifyResult.data.product;
   const variants = shopifyProduct.variants.edges.map((e) => e.node);
   const images = shopifyProduct.images.edges.map((e) => e.node);
+  const defaultVariant = variants[0];
   const selectableOptions = shopifyProduct.options.filter(
     (o) => o.values.length > 1
   );
+  const resolvedSelections: Record<string, string> = {};
+  for (const o of shopifyProduct.options) {
+    const fromUrl = sp[o.name];
+    const fallback =
+      defaultVariant?.selectedOptions.find((so) => so.name === o.name)?.value ??
+      "";
+    resolvedSelections[o.name] = fromUrl ?? fallback;
+  }
   const allOptionsSelected = selectableOptions.every((o) => {
-    const value = sp[o.name];
+    const value = resolvedSelections[o.name];
     return value !== undefined && o.values.includes(value);
   });
-  const selectedVariant = findVariantByOptions(variants, sp) ?? variants[0];
+  const selectedVariant =
+    findVariantByOptions(variants, resolvedSelections) ?? defaultVariant;
   if (!selectedVariant) {
     notFound();
   }


### PR DESCRIPTION
## Summary
- Fixes add-to-cart button being disabled on initial product page load despite the default variant being visually selected
- Root cause: page checked raw URL search params for option selection, but the variant selector falls back to the default variant's options when no params exist
- Now uses the same resolved selections logic as the variant selector

## Test plan
- [x] Navigate to a product page with no URL params — add-to-cart should be enabled
- [x] Select a different variant — add-to-cart should remain enabled
- [x] Direct URL with variant params (e.g. `?Color=Red&Size=M`) should still work