### PR TITLE
chore: redesign 404 page

### DIFF
--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -2,18 +2,32 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-[calc(100vh-400px)] flex-col items-center justify-center gap-4 p-4">
-      <h1 className="animate-bounce font-bold text-6xl text-foreground">404</h1>
-      <p className="animate-fade-in text-lg text-muted-foreground">
-        The page you are looking for does not exist.
+    <div className="container mx-auto flex h-screen flex-col items-center justify-center px-4">
+      <p className="select-none font-(family-name:--font-geist-pixel-square) text-[10rem] leading-none text-foreground md:text-[14rem] lg:text-[24rem]">
+        404
       </p>
-      <Link
-        aria-label="Return Home"
-        className="animate-fade-in-up rounded-md bg-primary px-4 py-2 font-medium text-primary-foreground text-sm transition-all duration-200 ease-in-out hover:scale-105 hover:bg-primary/90"
-        href="/"
-      >
-        Return Home
-      </Link>
+      <div className="flex flex-col items-center gap-4">
+        <h1 className="font-light text-3xl tracking-tight md:text-4xl">
+          This page doesn&apos;t exist
+        </h1>
+        <p className="text-muted-foreground text-sm tracking-wide">
+          The page you were looking for could not be found.
+        </p>
+        <div className="mt-4 flex gap-3">
+          <Link
+            href="/collections"
+            className="rounded-none border border-foreground bg-foreground px-6 py-2.5 text-sm uppercase text-background tracking-wider transition-colors hover:bg-transparent hover:text-foreground"
+          >
+            Back to Shop
+          </Link>
+          <Link
+            href="/"
+            className="rounded-none border border-foreground bg-transparent px-6 py-2.5 text-sm uppercase text-foreground tracking-wider transition-colors hover:bg-foreground hover:text-background"
+          >
+            Go Home
+          </Link>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Redesigns the 404 page with full-height centered layout
- Oversized pixel font (`--font-geist-pixel-square`) 404 as the hero element
- Clean headline and subtitle below
- Dual CTA buttons (Back to Shop / Go Home) in the site's brutalist `rounded-none` uppercase style
- Removes bounce animation in favor of a static, confident design

## Test plan
- [x] Navigate to a non-existent URL and verify the 404 page renders correctly
- [x] Verify full-height layout fills the viewport
- [ ] Test both CTA buttons link correctly
- [ ] Check responsive sizing across mobile/tablet/desktop

## Screenshot
<img width="1110" height="1297" alt="Screenshot 2026-03-10 at 13 45 37" src="https://github.com/user-attachments/assets/cb49bd9d-ab11-471d-8f5b-362e00911f60" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the 404 error page with updated typography, centered layout structure, and enhanced visual styling featuring prominent error indicators, bordered uppercase buttons, and smooth hover color transitions.

* **New Features**
  * Expanded 404 page navigation from a single return button to two action buttons: "Back to Shop" and "Go Home" with distinct links to collections and homepage respectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->