### PR TITLE
fix: resolve 404s for navbar/footer page links

### DIFF
--- a/apps/web/src/components/elements/rich-text.tsx
+++ b/apps/web/src/components/elements/rich-text.tsx
@@ -57,7 +57,7 @@ const components: Partial<PortableTextReactComponents> = {
   },
   marks: {
     code: ({ children }) => (
-      <code className="rounded-md border border-white/10 bg-opacity-5 p-1 text-sm lg:whitespace-nowrap">
+      <code className="border border-white/10 bg-opacity-5 p-1 text-sm lg:whitespace-nowrap">
         {children}
       </code>
     ),
@@ -127,7 +127,7 @@ const components: Partial<PortableTextReactComponents> = {
       return (
         <figure className="my-4">
           <SanityImage
-            className="h-auto w-full rounded-lg"
+            className="h-auto w-full "
             height={900}
             image={value}
             width={1600}

--- a/apps/web/src/components/elements/sanity-buttons.tsx
+++ b/apps/web/src/components/elements/sanity-buttons.tsx
@@ -29,7 +29,7 @@ function SanityButton({
       variant={variant}
       {...props}
       asChild
-      className={cn("rounded-[10px]", className)}
+      className={cn("rounded-none", className)}
     >
       <Link
         aria-label={`Navigate to ${text}`}

--- a/apps/web/src/components/sections/cta.tsx
+++ b/apps/web/src/components/sections/cta.tsx
@@ -10,7 +10,7 @@ export function CTABlock({ richText, title, eyebrow, buttons }: CTABlockProps) {
   return (
     <section className="my-6 md:my-16" id="features">
       <div className="container mx-auto px-4 md:px-8">
-        <div className="rounded-3xl bg-muted px-4 py-16">
+        <div className="bg-muted px-4 py-16">
           <div className="mx-auto max-w-3xl space-y-8 text-center">
             {eyebrow && (
               <Badge

--- a/apps/web/src/components/sections/feature-cards-with-icon.tsx
+++ b/apps/web/src/components/sections/feature-cards-with-icon.tsx
@@ -13,8 +13,8 @@ type FeatureCardProps = {
 function FeatureCard({ card }: FeatureCardProps) {
   const { icon, title, richText } = card ?? {};
   return (
-    <div className="rounded-3xl bg-accent p-8 md:min-h-[300px] md:p-8">
-      <span className="mb-9 flex w-fit items-center justify-center rounded-full bg-background p-3 drop-shadow-xl">
+    <div className="bg-accent p-8 md:min-h-75 md:p-8">
+      <span className="mb-9 flex w-fit items-center justify-center bg-background p-3 drop-shadow-xl">
         <SanityIcon icon={icon} />
       </span>
 

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
 const badgeVariants = cva(
-  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-md border px-2 py-0.5 font-medium text-xs transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap border px-2 py-1 font-medium text-xs transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- Removed rounded corners (rounded-3xl, rounded-md, rounded-full, rounded-lg) from CTA, feature cards, badge, rich text, and button components to match the sharp corners design system
- Seeded 4 missing page documents in Sanity (Help Center, Returns, Privacy Policy, Terms of Service) with hero and feature card content blocks so navbar/footer links no longer 404

## Verification

Run `pnpm dev:web` and confirm these routes load with content:
- [x] `/help`
- [x] `/returns`
- [x] `/privacy`
- [x] `/terms`
- [x] `/about-us` (already existed, slug corrected in Sanity)
- [x] Navbar "About" link navigates correctly
- [x] All footer links navigate correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined UI design by removing rounded borders and corner radius from multiple components, including buttons, code blocks, feature cards, and badges throughout the app for a more angular aesthetic. Updated spacing and padding on select elements to maintain visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->