### PR TITLE
fix: make blog author image a fixed square

### DIFF
--- a/apps/web/src/components/blog-card.tsx
+++ b/apps/web/src/components/blog-card.tsx
@@ -30,10 +30,10 @@ export function BlogAuthor({ author }: BlogAuthorProps) {
       {author.image && (
         <SanityImage
           alt={author.name ?? "Author"}
-          className="size-8 flex-none bg-muted"
-          height={40}
+          className="h-8 w-8 flex-none bg-muted object-cover"
+          height={32}
           image={author.image}
-          width={40}
+          width={32}
         />
       )}
       {author.name}


### PR DESCRIPTION
## Summary
- Changed the blog author avatar to use explicit `h-8 w-8` (32px) with `object-cover` for a consistent square image

## Test plan
- [x] Verify author avatar renders as a 32×32 square on blog list and detail pages
- [x] Confirm image crops correctly with `object-cover`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined blog card author image display by adjusting dimensions and enhancing image cropping for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->