### PR TITLE
Point license credit at robotostudio.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,4 +274,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to th
 
 ## License
 
-[MIT](LICENSE) &copy; [Roboto Studio](https://roboto.studio/)
+[MIT](LICENSE) &copy; [Roboto Studio](https://robotostudio.com)


### PR DESCRIPTION
The license footer linked the old roboto.studio domain. Points it at robotostudio.com instead.

Fixes part of ROB-2081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license attribution URL in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->