### PR TITLE
perf: serve resized Shopify CDN images via custom `next/image` loader

### DIFF
--- a/apps/web/src/components/cart/cart-line-item.tsx
+++ b/apps/web/src/components/cart/cart-line-item.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { Trash2 } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 
 import { AnimatedMoney } from "@/components/elements/animated-money";
 import { BookmarkIcon } from "@/components/icons";
 import { QuantitySelector } from "@/components/product/quantity-selector";
+import { ShopifyImage as Image } from "@/components/product/shopify-image";
 import { useSavedItems } from "@/components/saved-items/saved-items-context";
 import { isSyntheticLineId } from "@/lib/cart/intents";
 import { getColorHex } from "@/lib/shopify/color";

--- a/apps/web/src/components/collection/collection-card.tsx
+++ b/apps/web/src/components/collection/collection-card.tsx
@@ -1,5 +1,6 @@
-import Image from "next/image";
 import Link from "next/link";
+
+import { ShopifyImage as Image } from "@/components/product/shopify-image";
 
 export type CollectionCardProps = {
   handle: string;

--- a/apps/web/src/components/product/product-card.tsx
+++ b/apps/web/src/components/product/product-card.tsx
@@ -2,11 +2,11 @@
 
 import { Badge } from "@workspace/ui/components/badge";
 import { cn } from "@workspace/ui/lib/utils";
-import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
 
 import { useCartActions } from "@/components/cart/cart-context";
+import { ShopifyImage as Image } from "@/components/product/shopify-image";
 import { SavedItemButton } from "@/components/saved-items/saved-item-button";
 import { buildLineMetadata } from "@/lib/cart/metadata";
 import { formatMoney } from "@/lib/shopify/money";

--- a/apps/web/src/components/product/product-gallery.tsx
+++ b/apps/web/src/components/product/product-gallery.tsx
@@ -2,11 +2,11 @@
 
 import { cn } from "@workspace/ui/lib/utils";
 import { ZoomIn } from "lucide-react";
-import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 
 import type { ShopifyImage } from "@/lib/shopify/types";
 import { ProductLightbox } from "./product-lightbox";
+import { ShopifyImage as ShopifyImageEl } from "./shopify-image";
 
 type ProductGalleryProps = {
   images: ShopifyImage[];
@@ -95,7 +95,7 @@ function GalleryDesktop({
               type="button"
             >
               <div className="card-surface relative aspect-3/4 w-full overflow-hidden">
-                <Image
+                <ShopifyImageEl
                   alt={image.altText ?? `Thumbnail ${index + 1}`}
                   className="object-cover"
                   fill
@@ -121,7 +121,7 @@ function GalleryDesktop({
             }}
             type="button"
           >
-            <Image
+            <ShopifyImageEl
               alt={image.altText ?? "Product image"}
               className="object-cover"
               fill
@@ -222,7 +222,7 @@ function GalleryMobile({
             }}
             type="button"
           >
-            <Image
+            <ShopifyImageEl
               alt={image.altText ?? "Product image"}
               className="object-cover"
               fill
@@ -247,7 +247,7 @@ function GalleryMobile({
               type="button"
             >
               <div className="card-surface relative h-16 w-12 overflow-hidden">
-                <Image
+                <ShopifyImageEl
                   alt={image.altText ?? `Thumbnail ${index + 1}`}
                   className="object-cover"
                   fill

--- a/apps/web/src/components/product/shopify-image.tsx
+++ b/apps/web/src/components/product/shopify-image.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Image, { type ImageProps } from "next/image";
+
+import {
+  shopifyBlurDataURL,
+  shopifyImageLoader,
+} from "@/lib/shopify/image-loader";
+
+/**
+ * `next/image` wrapper for Shopify CDN images. Applies the Shopify loader (so
+ * the CDN resizes instead of the Vercel optimizer downloading masters) and a
+ * blur-up placeholder by default. Non-Shopify `src` values fall through to the
+ * default optimizer and whatever placeholder the caller passed.
+ */
+export function ShopifyImage({
+  src,
+  placeholder,
+  blurDataURL,
+  ...props
+}: ImageProps) {
+  const isShopify = typeof src === "string" && src.includes("cdn.shopify.com");
+
+  return (
+    <Image
+      blurDataURL={isShopify ? shopifyBlurDataURL(src) : blurDataURL}
+      loader={isShopify ? shopifyImageLoader : undefined}
+      placeholder={isShopify ? "blur" : placeholder}
+      src={src}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/lib/shopify/image-loader.ts
+++ b/apps/web/src/lib/shopify/image-loader.ts
@@ -1,0 +1,52 @@
+import type { ImageLoaderProps } from "next/image";
+
+const SHOPIFY_CDN_HOST = "cdn.shopify.com";
+
+function isShopifyUrl(src: string): boolean {
+  return src.includes(SHOPIFY_CDN_HOST);
+}
+
+/**
+ * A custom `next/image` loader for Shopify CDN images.
+ *
+ * Shopify's CDN resizes and reformats images on the fly via URL params
+ * (`?width=`, `&height=`, `&crop=`). By mapping Next's requested width onto
+ * Shopify's `width` param we let Shopify's global CDN do the resizing — fast,
+ * cached, and free — instead of forcing the Vercel optimizer to first download
+ * the full-resolution master. Next still calls this once per `deviceSizes`
+ * width, so we keep a correct responsive `srcset`.
+ *
+ * Non-Shopify URLs are returned untouched so this loader is safe to attach to
+ * any image.
+ */
+export function shopifyImageLoader({
+  src,
+  width,
+  quality,
+}: ImageLoaderProps): string {
+  if (!isShopifyUrl(src)) {
+    return src;
+  }
+
+  const url = new URL(src);
+  url.searchParams.set("width", String(width));
+  url.searchParams.set("quality", String(quality ?? 75));
+  return url.toString();
+}
+
+/**
+ * A tiny, low-quality Shopify variant of the same image, used as the
+ * `blurDataURL` for `placeholder="blur"`. This renders a blurry preview
+ * instantly and sharpens to the full image as it loads (the "blur-up" effect).
+ * Returns the original `src` unchanged for non-Shopify URLs.
+ */
+export function shopifyBlurDataURL(src: string): string {
+  if (!isShopifyUrl(src)) {
+    return src;
+  }
+
+  const url = new URL(src);
+  url.searchParams.set("width", "24");
+  url.searchParams.set("quality", "30");
+  return url.toString();
+}


### PR DESCRIPTION
## Problem / Intent
Product images loaded slowly. Every Shopify `<Image>` was handed the raw Shopify **master** URL (multi-MB, full resolution) with no size transform. In production this forced Vercel's image optimizer to download the full master from Shopify server-side before it could resize and serve it — a cold-start latency + extra hop on first view. Thumbnails were the worst case: a 54px thumbnail still made the optimizer pull down the entire master. There was also no placeholder, so images popped in against a blank surface.

## Approach
Add a custom `next/image` loader (`shopifyImageLoader`) that maps Next's requested width onto Shopify's native CDN transform params (`?width=&quality=`). Now the browser requests an already-resized image straight from Shopify's global CDN — no Vercel optimizer, no master download, no middle hop — while Next still generates a correct responsive `srcset`. A `ShopifyImage` wrapper applies the loader plus a blur-up placeholder (`?width=24`) by default.

Swapped the raw `<Image>` usages on the hot paths to `ShopifyImage`:
- `product-gallery.tsx` (PDP gallery — main + thumbnails, desktop + mobile)
- `product-card.tsx` (grid/homepage cards; related-products & search grids reuse this)
- `collection-card.tsx` (collection tiles)
- `cart-line-item.tsx` (cart drawer)

No change to `next.config.ts`: the loader bypasses the optimizer for Shopify images, so the existing `unoptimized: development` flag is untouched.

## PREVIEW 
# BEFORE
<img width="1800" height="1169" alt="Screenshot 2026-07-24 at 17 21 01" src="https://github.com/user-attachments/assets/165046f6-005c-4427-81b8-4f4d66474370" />

# AFTER
<img width="1800" height="1169" alt="Screenshot 2026-07-24 at 17 31 47" src="https://github.com/user-attachments/assets/e4ef7ab7-414e-4750-8946-55c00057c85c" />


## How to test
1. Open a PDP on the preview, e.g. `/products/foundry-cotton-overshirt`.
2. DevTools → Network → Img, inspect a product image request.
   - Expected: URL is `cdn.shopify.com/...?width=<N>&quality=75`, file is tens of KB, and there is a `srcset` listing several `?width=` sizes.
   - Old behavior would have been a raw `cdn.shopify.com/.../file.jpg` master (multi-MB, no `?width=`).
3. Resize the viewport and reload → the served `width` param tracks the layout size (responsive srcset works).
4. On a throttled connection (Slow 4G), confirm the blur-up placeholder shows briefly before the sharp image.
5. Check the collection grid, homepage cards, and cart drawer images load the same resized/blur way.
6. Lightbox still opens instantly reusing the on-page image (no regression).