### PR TITLE
ROB-2414: fix: product card color swatch now swaps the product image

### DIFF
--- a/apps/web/src/components/cart/cart-recommendations.tsx
+++ b/apps/web/src/components/cart/cart-recommendations.tsx
@@ -4,28 +4,14 @@ import { Skeleton } from "@workspace/ui/components/skeleton";
 import { useQuery } from "@tanstack/react-query";
 
 import { ProductCard } from "@/components/product/product-card";
-import { getColorHex } from "@/lib/shopify/color";
-import { getCardOptions } from "@/lib/shopify/options";
-import { badgeFromTags, secondaryImageUrl } from "@/lib/shopify/product-card";
-import { type FeaturedProduct, LOW_STOCK_THRESHOLD } from "@/lib/shopify/types";
+import { collectionProductToCardProps } from "@/lib/shopify/product-card";
+import type { FeaturedProduct } from "@/lib/shopify/types";
 
 async function fetchFeaturedProducts(): Promise<FeaturedProduct[]> {
   const res = await fetch("/api/featured-products");
   if (!res.ok) return [];
   const data: { products: FeaturedProduct[] } = await res.json();
   return data.products;
-}
-
-function stockStatus(product: FeaturedProduct) {
-  if (!product.availableForSale) return "out" as const;
-  if (
-    product.totalInventory !== null &&
-    product.totalInventory > 0 &&
-    product.totalInventory <= LOW_STOCK_THRESHOLD
-  ) {
-    return "low" as const;
-  }
-  return null;
 }
 
 export function CartRecommendations() {
@@ -53,49 +39,11 @@ export function CartRecommendations() {
 
   return (
     <div className="-mr-8 flex gap-4 overflow-x-auto pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-      {products.map((product) => {
-        const { colors: colorNames, sizes } = getCardOptions(product.options);
-        const colors = colorNames.map((name) => ({
-          name,
-          hex: getColorHex(name),
-        }));
-        return (
-          <div className="w-[340px] shrink-0" key={product.id}>
-            <ProductCard
-              badge={badgeFromTags(product.tags)}
-              colors={colors}
-              compareAtPrice={
-                product.compareAtPriceRange
-                  ? Number(product.compareAtPriceRange.minVariantPrice.amount)
-                  : null
-              }
-              currencyCode={product.priceRange.minVariantPrice.currencyCode}
-              imageUrl={product.featuredImage?.url ?? null}
-              secondaryImageUrl={secondaryImageUrl(
-                product.images,
-                product.featuredImage?.url ?? null
-              )}
-              priceRange={{
-                minVariantPrice: Number(
-                  product.priceRange.minVariantPrice.amount
-                ),
-                maxVariantPrice: Number(
-                  product.priceRange.maxVariantPrice.amount
-                ),
-              }}
-              selectedColor={colorNames[0]}
-              selectedSize={sizes[0]}
-              sizes={sizes}
-              slug={product.handle}
-              stockStatus={stockStatus(product)}
-              title={product.title}
-              variantName={colorNames[0]}
-              variants={product.variants.edges.map((edge) => edge.node)}
-              vendor={product.vendor}
-            />
-          </div>
-        );
-      })}
+      {products.map((product) => (
+        <div className="w-[340px] shrink-0" key={product.id}>
+          <ProductCard {...collectionProductToCardProps(product)} />
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/components/product/product-card.tsx
+++ b/apps/web/src/components/product/product-card.tsx
@@ -10,7 +10,9 @@ import { useCartActions } from "@/components/cart/cart-context";
 import { SavedItemButton } from "@/components/saved-items/saved-item-button";
 import { buildLineMetadata } from "@/lib/cart/metadata";
 import { formatMoney } from "@/lib/shopify/money";
-import type { MoneyV2 } from "@/lib/shopify/types";
+import { findCardVariant, resolveCardImages } from "@/lib/shopify/product-card";
+import type { MoneyV2, ShopifyImage } from "@/lib/shopify/types";
+import { buildVariantUrl } from "@/lib/shopify/variant-utils";
 
 export type MerchBadge = "new" | "exclusive";
 export type StockStatus = "low" | "out" | null;
@@ -20,6 +22,8 @@ export type CardVariant = {
   availableForSale: boolean;
   price: MoneyV2;
   selectedOptions: { name: string; value: string }[];
+  /** Per-variant photo; drives the card's image swap on color select. */
+  image?: ShopifyImage | null;
 };
 
 export type ProductCardProps = {
@@ -46,8 +50,12 @@ export type ProductCardProps = {
   colors?: CardColor[];
   /** Initially selected color name (rendered as the taller, underlined swatch). */
   selectedColor?: string;
+  /** Shopify's own name for the color option, used to link into the PDP. */
+  colorOptionName?: string;
   /** Variants for resolving the color+size selection to a cart line. */
   variants?: CardVariant[];
+  /** Ordered gallery URLs; locates the hover partner for a color's photo. */
+  galleryUrls?: string[];
   mini?: boolean;
 };
 
@@ -60,21 +68,6 @@ const MERCH_BADGE_CLASS = "px-1.5 py-0.5";
 
 function money(amount: number, currencyCode: string) {
   return formatMoney({ amount: String(amount), currencyCode });
-}
-
-/** Finds the variant matching the selected color and size values. */
-function resolveVariant(
-  variants: CardVariant[] | undefined,
-  color: string | undefined,
-  size: string | undefined
-): CardVariant | undefined {
-  if (!variants || variants.length === 0) return undefined;
-  return variants.find((variant) => {
-    const values = variant.selectedOptions.map((option) => option.value);
-    return (
-      (!color || values.includes(color)) && (!size || values.includes(size))
-    );
-  });
 }
 
 function ProductCardMini({
@@ -265,7 +258,7 @@ function AddToCartBar({
 }) {
   const { addLine, openCart } = useCartActions();
 
-  const variant = resolveVariant(variants, selectedColor, selectedSize);
+  const variant = findCardVariant(variants, selectedColor, selectedSize);
   const canAdd = Boolean(variant?.availableForSale);
 
   function handleAdd() {
@@ -354,6 +347,32 @@ function CardImage({
   );
 }
 
+/** Display price, strikethrough figure and discount percentage for a card. */
+function cardPricing(
+  priceRange: ProductCardProps["priceRange"],
+  compareAtPrice: number | null | undefined,
+  code: string
+) {
+  const price = money(priceRange.minVariantPrice, code);
+  const showRange = priceRange.minVariantPrice !== priceRange.maxVariantPrice;
+  const rangePrice = showRange ? money(priceRange.maxVariantPrice, code) : null;
+
+  const onSale =
+    typeof compareAtPrice === "number" &&
+    compareAtPrice > priceRange.minVariantPrice;
+  if (!(onSale && compareAtPrice)) {
+    return { price, salePercent: 0, strikePrice: rangePrice };
+  }
+
+  return {
+    price,
+    salePercent: Math.round(
+      ((compareAtPrice - priceRange.minVariantPrice) / compareAtPrice) * 100
+    ),
+    strikePrice: money(compareAtPrice, code),
+  };
+}
+
 export function ProductCard({
   slug,
   title,
@@ -370,15 +389,20 @@ export function ProductCard({
   selectedSize: initialSize,
   colors,
   selectedColor: initialColor,
+  colorOptionName,
   variants,
+  galleryUrls,
   mini,
 }: ProductCardProps) {
   const [selectedColor, setSelectedColor] = useState(initialColor);
   const [selectedSize, setSelectedSize] = useState(initialSize);
 
   const code = currencyCode ?? "GBP";
-  const price = money(priceRange.minVariantPrice, code);
-  const showRange = priceRange.minVariantPrice !== priceRange.maxVariantPrice;
+  const { price, salePercent, strikePrice } = cardPricing(
+    priceRange,
+    compareAtPrice,
+    code
+  );
 
   if (mini) {
     return (
@@ -386,28 +410,25 @@ export function ProductCard({
         imageUrl={imageUrl}
         price={price}
         slug={slug}
-        strikePrice={showRange ? money(priceRange.maxVariantPrice, code) : null}
+        strikePrice={strikePrice}
         title={title}
       />
     );
   }
 
-  const onSale =
-    typeof compareAtPrice === "number" &&
-    compareAtPrice > priceRange.minVariantPrice;
-  const salePercent =
-    onSale && compareAtPrice
-      ? Math.round(
-          ((compareAtPrice - priceRange.minVariantPrice) / compareAtPrice) * 100
-        )
-      : 0;
-  const strikePrice = onSale
-    ? money(compareAtPrice, code)
-    : showRange
-      ? money(priceRange.maxVariantPrice, code)
-      : null;
   const subtitle = selectedColor ?? variantName ?? vendor;
-  const href = `/products/${slug}`;
+  // Carry the chosen color into the PDP so the selection survives navigation.
+  const href =
+    selectedColor && colorOptionName
+      ? buildVariantUrl(slug, { [colorOptionName]: selectedColor })
+      : `/products/${slug}`;
+  const { primary, secondary } = resolveCardImages({
+    selectedColor,
+    variants,
+    galleryUrls,
+    imageUrl,
+    secondaryImageUrl,
+  });
 
   return (
     <div className="group relative">
@@ -418,8 +439,8 @@ export function ProductCard({
           href={href}
         >
           <CardImage
-            imageUrl={imageUrl}
-            secondaryImageUrl={secondaryImageUrl}
+            imageUrl={primary}
+            secondaryImageUrl={secondary}
             title={title}
           />
         </Link>
@@ -433,7 +454,7 @@ export function ProductCard({
         {/* Hover add-to-cart bar — inset 8px on the image */}
         {stockStatus !== "out" && variants && variants.length > 0 && (
           <AddToCartBar
-            imageUrl={imageUrl}
+            imageUrl={primary}
             onSelectSize={setSelectedSize}
             productHandle={slug}
             productTitle={title}

--- a/apps/web/src/components/product/product-card.tsx
+++ b/apps/web/src/components/product/product-card.tsx
@@ -9,9 +9,12 @@ import { useState } from "react";
 import { useCartActions } from "@/components/cart/cart-context";
 import { SavedItemButton } from "@/components/saved-items/saved-item-button";
 import { buildLineMetadata } from "@/lib/cart/metadata";
-import { formatMoney } from "@/lib/shopify/money";
-import { findCardVariant, resolveCardImages } from "@/lib/shopify/product-card";
-import type { MoneyV2, ShopifyImage } from "@/lib/shopify/types";
+import {
+  cardPricing,
+  findCardVariant,
+  resolveCardImages,
+} from "@/lib/shopify/product-card";
+import type { CardImageFields, MoneyV2 } from "@/lib/shopify/types";
 import { buildVariantUrl } from "@/lib/shopify/variant-utils";
 
 export type MerchBadge = "new" | "exclusive";
@@ -23,7 +26,7 @@ export type CardVariant = {
   price: MoneyV2;
   selectedOptions: { name: string; value: string }[];
   /** Per-variant photo; drives the card's image swap on color select. */
-  image?: ShopifyImage | null;
+  image?: CardImageFields | null;
 };
 
 export type ProductCardProps = {
@@ -66,22 +69,20 @@ const BADGE_LABEL: Record<MerchBadge, string> = {
 
 const MERCH_BADGE_CLASS = "px-1.5 py-0.5";
 
-function money(amount: number, currencyCode: string) {
-  return formatMoney({ amount: String(amount), currencyCode });
-}
-
 function ProductCardMini({
   slug,
   title,
   imageUrl,
   price,
   strikePrice,
+  rangePrice,
 }: {
   slug: string;
   title: string;
   imageUrl: string | null;
   price: string;
   strikePrice: string | null;
+  rangePrice: string | null;
 }) {
   return (
     <Link
@@ -105,6 +106,7 @@ function ProductCardMini({
         <p className="truncate font-medium text-sm">{title}</p>
         <p className="text-muted-foreground text-xs">
           {price}
+          {rangePrice && <span className="ml-1">– {rangePrice}</span>}
           {strikePrice && (
             <span className="ml-1 line-through">{strikePrice}</span>
           )}
@@ -347,32 +349,6 @@ function CardImage({
   );
 }
 
-/** Display price, strikethrough figure and discount percentage for a card. */
-function cardPricing(
-  priceRange: ProductCardProps["priceRange"],
-  compareAtPrice: number | null | undefined,
-  code: string
-) {
-  const price = money(priceRange.minVariantPrice, code);
-  const showRange = priceRange.minVariantPrice !== priceRange.maxVariantPrice;
-  const rangePrice = showRange ? money(priceRange.maxVariantPrice, code) : null;
-
-  const onSale =
-    typeof compareAtPrice === "number" &&
-    compareAtPrice > priceRange.minVariantPrice;
-  if (!(onSale && compareAtPrice)) {
-    return { price, salePercent: 0, strikePrice: rangePrice };
-  }
-
-  return {
-    price,
-    salePercent: Math.round(
-      ((compareAtPrice - priceRange.minVariantPrice) / compareAtPrice) * 100
-    ),
-    strikePrice: money(compareAtPrice, code),
-  };
-}
-
 export function ProductCard({
   slug,
   title,
@@ -398,7 +374,7 @@ export function ProductCard({
   const [selectedSize, setSelectedSize] = useState(initialSize);
 
   const code = currencyCode ?? "GBP";
-  const { price, salePercent, strikePrice } = cardPricing(
+  const { price, salePercent, strikePrice, rangePrice } = cardPricing(
     priceRange,
     compareAtPrice,
     code
@@ -409,6 +385,7 @@ export function ProductCard({
       <ProductCardMini
         imageUrl={imageUrl}
         price={price}
+        rangePrice={rangePrice}
         slug={slug}
         strikePrice={strikePrice}
         title={title}
@@ -483,6 +460,11 @@ export function ProductCard({
           </div>
           <p className="font-medium text-base text-foreground">
             {price}
+            {rangePrice && (
+              <span className="ml-1.5 font-normal text-muted-foreground">
+                – {rangePrice}
+              </span>
+            )}
             {strikePrice && (
               <span className="ml-1.5 font-normal text-muted-foreground line-through">
                 {strikePrice}

--- a/apps/web/src/components/product/related-products.tsx
+++ b/apps/web/src/components/product/related-products.tsx
@@ -3,74 +3,12 @@ import Link from "next/link";
 
 import { storefrontQuery } from "@/lib/shopify/client";
 import { collectionProductToCardProps } from "@/lib/shopify/product-card";
-import type { ShopifyCollectionProduct } from "@/lib/shopify/types";
+import { RELATED_PRODUCTS_QUERY } from "@/lib/shopify/queries";
+import type { CardSourceProduct } from "@/lib/shopify/types";
 import { ProductCard } from "./product-card";
 
-const RELATED_PRODUCTS_QUERY = /* graphql */ `
-  query RelatedProducts($productId: ID!) {
-    productRecommendations(productId: $productId) {
-      id
-      handle
-      title
-      vendor
-      productType
-      tags
-      options {
-        id
-        name
-        values
-      }
-      featuredImage {
-        url
-        altText
-        width
-        height
-      }
-      images(first: 2) {
-        edges {
-          node {
-            url
-            altText
-            width
-            height
-          }
-        }
-      }
-      priceRange {
-        minVariantPrice {
-          amount
-          currencyCode
-        }
-        maxVariantPrice {
-          amount
-          currencyCode
-        }
-      }
-      compareAtPriceRange {
-        minVariantPrice {
-          amount
-          currencyCode
-        }
-      }
-      variants(first: 100) {
-        edges {
-          node {
-            id
-            availableForSale
-            quantityAvailable
-            selectedOptions {
-              name
-              value
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
 type RelatedProductsResponse = {
-  productRecommendations: ShopifyCollectionProduct[];
+  productRecommendations: CardSourceProduct[];
 };
 
 type RelatedProductsProps = {

--- a/apps/web/src/components/sections/featured-products.tsx
+++ b/apps/web/src/components/sections/featured-products.tsx
@@ -1,31 +1,14 @@
 import { Button } from "@workspace/ui/components/button";
 import Link from "next/link";
 
-import {
-  ProductCard,
-  type StockStatus,
-} from "@/components/product/product-card";
-import { getColorHex } from "@/lib/shopify/color";
-import { getCardOptions } from "@/lib/shopify/options";
-import { badgeFromTags, secondaryImageUrl } from "@/lib/shopify/product-card";
-import { type FeaturedProduct, LOW_STOCK_THRESHOLD } from "@/lib/shopify/types";
+import { ProductCard } from "@/components/product/product-card";
+import { collectionProductToCardProps } from "@/lib/shopify/product-card";
+import type { FeaturedProduct } from "@/lib/shopify/types";
 
 type FeaturedProductsProps = {
   heading?: string | null;
   products: FeaturedProduct[];
 };
-
-function featuredStock(product: FeaturedProduct): StockStatus {
-  if (!product.availableForSale) return "out";
-  if (
-    product.totalInventory !== null &&
-    product.totalInventory > 0 &&
-    product.totalInventory <= LOW_STOCK_THRESHOLD
-  ) {
-    return "low";
-  }
-  return null;
-}
 
 export function FeaturedProducts({ heading, products }: FeaturedProductsProps) {
   if (products.length === 0) return null;
@@ -42,48 +25,12 @@ export function FeaturedProducts({ heading, products }: FeaturedProductsProps) {
       </div>
 
       <div className="grid grid-cols-2 gap-1 md:grid-cols-4">
-        {products.map((product) => {
-          const { colors: colorNames, sizes } = getCardOptions(product.options);
-          const colors = colorNames.map((name) => ({
-            name,
-            hex: getColorHex(name),
-          }));
-          return (
-            <ProductCard
-              badge={badgeFromTags(product.tags)}
-              colors={colors}
-              compareAtPrice={
-                product.compareAtPriceRange
-                  ? Number(product.compareAtPriceRange.minVariantPrice.amount)
-                  : null
-              }
-              currencyCode={product.priceRange.minVariantPrice.currencyCode}
-              imageUrl={product.featuredImage?.url ?? null}
-              key={product.id}
-              secondaryImageUrl={secondaryImageUrl(
-                product.images,
-                product.featuredImage?.url ?? null
-              )}
-              priceRange={{
-                minVariantPrice: Number(
-                  product.priceRange.minVariantPrice.amount
-                ),
-                maxVariantPrice: Number(
-                  product.priceRange.maxVariantPrice.amount
-                ),
-              }}
-              selectedColor={colorNames[0]}
-              selectedSize={sizes[0]}
-              sizes={sizes}
-              slug={product.handle}
-              stockStatus={featuredStock(product)}
-              title={product.title}
-              variantName={colorNames[0]}
-              variants={product.variants.edges.map((edge) => edge.node)}
-              vendor={product.vendor}
-            />
-          );
-        })}
+        {products.map((product) => (
+          <ProductCard
+            key={product.id}
+            {...collectionProductToCardProps(product)}
+          />
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/lib/shopify/__tests__/product-card.test.ts
+++ b/apps/web/src/lib/shopify/__tests__/product-card.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardVariant } from "@/components/product/product-card";
+import { findCardVariant, resolveCardImages } from "@/lib/shopify/product-card";
+
+const price = { amount: "10.00", currencyCode: "GBP" };
+
+const img = (url: string) => ({ url, altText: null, width: 0, height: 0 });
+
+/** Builds a variant from "Color/Size" plus an optional variant photo. */
+function variant(
+  color: string,
+  size: string,
+  imageUrl?: string,
+  overrides: Partial<CardVariant> = {}
+): CardVariant {
+  return {
+    id: `${color}-${size}`,
+    availableForSale: true,
+    price,
+    selectedOptions: [
+      { name: "Color", value: color },
+      { name: "Size", value: size },
+    ],
+    image: imageUrl ? img(imageUrl) : null,
+    ...overrides,
+  };
+}
+
+// Two colors, two photos each — the layout resolveCardImages is built around.
+const NAVY_A = "navy-a.jpg";
+const NAVY_B = "navy-b.jpg";
+const SAND_A = "sand-a.jpg";
+const SAND_B = "sand-b.jpg";
+const GALLERY = [NAVY_A, NAVY_B, SAND_A, SAND_B];
+const VARIANTS = [
+  variant("Navy", "S", NAVY_A),
+  variant("Navy", "M", NAVY_A),
+  variant("Sand", "S", SAND_A),
+  variant("Sand", "M", SAND_A),
+];
+
+const base = {
+  variants: VARIANTS,
+  galleryUrls: GALLERY,
+  imageUrl: NAVY_A,
+  secondaryImageUrl: NAVY_B,
+};
+
+describe("resolveCardImages", () => {
+  it("swaps to the selected color's variant photo", () => {
+    expect(resolveCardImages({ ...base, selectedColor: "Sand" })).toEqual({
+      primary: SAND_A,
+      secondary: SAND_B,
+    });
+  });
+
+  it("uses the next gallery image as the hover partner", () => {
+    expect(resolveCardImages({ ...base, selectedColor: "Navy" })).toEqual({
+      primary: NAVY_A,
+      secondary: NAVY_B,
+    });
+  });
+
+  it("does not cross-fade into the next color when a color has one photo", () => {
+    // Navy has a single photo, so the next gallery entry opens Sand's group.
+    const gallery = [NAVY_A, SAND_A, SAND_B];
+    const result = resolveCardImages({
+      selectedColor: "Navy",
+      variants: [variant("Navy", "S", NAVY_A), variant("Sand", "S", SAND_A)],
+      galleryUrls: gallery,
+      imageUrl: NAVY_A,
+      secondaryImageUrl: SAND_A,
+    });
+    expect(result).toEqual({ primary: NAVY_A, secondary: null });
+  });
+
+  it("has no hover partner for the last image in the gallery", () => {
+    const result = resolveCardImages({
+      ...base,
+      selectedColor: "Sand",
+      galleryUrls: [NAVY_A, NAVY_B, SAND_A],
+    });
+    expect(result).toEqual({ primary: SAND_A, secondary: null });
+  });
+
+  it("keeps the product-level hover when the photo is outside the gallery window", () => {
+    const result = resolveCardImages({
+      ...base,
+      selectedColor: "Sand",
+      galleryUrls: [NAVY_A, NAVY_B],
+    });
+    expect(result).toEqual({ primary: SAND_A, secondary: NAVY_B });
+  });
+
+  it("falls back to the product images when the color has no photo", () => {
+    const result = resolveCardImages({
+      ...base,
+      selectedColor: "Sand",
+      variants: [variant("Navy", "S", NAVY_A), variant("Sand", "S")],
+    });
+    expect(result).toEqual({ primary: NAVY_A, secondary: NAVY_B });
+  });
+
+  it("falls back when no color is selected", () => {
+    expect(resolveCardImages({ ...base, selectedColor: undefined })).toEqual({
+      primary: NAVY_A,
+      secondary: NAVY_B,
+    });
+  });
+
+  it("falls back when the product has no variants", () => {
+    expect(
+      resolveCardImages({ ...base, selectedColor: "Sand", variants: [] })
+    ).toEqual({ primary: NAVY_A, secondary: NAVY_B });
+  });
+
+  it("normalises a missing secondary to null", () => {
+    const result = resolveCardImages({
+      ...base,
+      selectedColor: undefined,
+      secondaryImageUrl: undefined,
+    });
+    expect(result).toEqual({ primary: NAVY_A, secondary: null });
+  });
+
+  it("ignores a size whose value collides with the selected color", () => {
+    // A size literally named "Sand" must not be mistaken for the color.
+    const odd: CardVariant = {
+      id: "collide",
+      availableForSale: true,
+      price,
+      selectedOptions: [
+        { name: "Color", value: "Navy" },
+        { name: "Size", value: "Sand" },
+      ],
+      image: img("wrong.jpg"),
+    };
+    const result = resolveCardImages({
+      ...base,
+      selectedColor: "Sand",
+      variants: [odd, variant("Sand", "S", SAND_A)],
+    });
+    expect(result.primary).toBe(SAND_A);
+  });
+});
+
+describe("findCardVariant", () => {
+  it("matches on both color and size", () => {
+    expect(findCardVariant(VARIANTS, "Sand", "M")?.id).toBe("Sand-M");
+  });
+
+  it("matches per option type, not on bare values", () => {
+    const odd: CardVariant = {
+      id: "collide",
+      availableForSale: true,
+      price,
+      selectedOptions: [
+        { name: "Color", value: "M" },
+        { name: "Size", value: "Navy" },
+      ],
+    };
+    // The old value-only match would have returned `collide` here.
+    expect(findCardVariant([odd, ...VARIANTS], "Navy", "M")?.id).toBe("Navy-M");
+  });
+
+  it("ignores an unset selection", () => {
+    expect(findCardVariant(VARIANTS, "Sand", undefined)?.id).toBe("Sand-S");
+  });
+
+  it("returns undefined for an unknown combination", () => {
+    expect(findCardVariant(VARIANTS, "Sand", "XL")).toBeUndefined();
+  });
+
+  it("returns undefined when there are no variants", () => {
+    expect(findCardVariant([], "Sand", "M")).toBeUndefined();
+    expect(findCardVariant(undefined, "Sand", "M")).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/shopify/__tests__/product-card.test.ts
+++ b/apps/web/src/lib/shopify/__tests__/product-card.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import type { CardVariant } from "@/components/product/product-card";
-import { findCardVariant, resolveCardImages } from "@/lib/shopify/product-card";
+import {
+  cardPricing,
+  findCardVariant,
+  resolveCardImages,
+} from "@/lib/shopify/product-card";
 
 const price = { amount: "10.00", currencyCode: "GBP" };
 
-const img = (url: string) => ({ url, altText: null, width: 0, height: 0 });
+const img = (url: string) => ({ url });
 
 /** Builds a variant from "Color/Size" plus an optional variant photo. */
 function variant(
@@ -124,6 +128,72 @@ describe("resolveCardImages", () => {
     expect(result).toEqual({ primary: NAVY_A, secondary: null });
   });
 
+  // Storefront's ProductVariant.image "falls back to the product image if no
+  // image is available", so a color with no photo reports one anyway. An image
+  // claimed by two colors is that fallback, not a photo of either.
+  describe("inherited product images", () => {
+    const HERO = "product-hero.jpg";
+
+    it("ignores an image claimed by more than one color", () => {
+      const result = resolveCardImages({
+        selectedColor: "Sand",
+        variants: [variant("Navy", "S", HERO), variant("Sand", "S", HERO)],
+        galleryUrls: [HERO, "gallery-02.jpg"],
+        imageUrl: HERO,
+        secondaryImageUrl: "product-secondary.jpg",
+      });
+      // Without detection this would walk the gallery to "gallery-02.jpg".
+      expect(result).toEqual({
+        primary: HERO,
+        secondary: "product-secondary.jpg",
+      });
+    });
+
+    it("falls back for every color once an image is shared", () => {
+      // Navy really does own NAVY_A, but Sand inheriting it makes the two
+      // indistinguishable — falling back is the safe read.
+      const variants = [
+        variant("Navy", "S", NAVY_A),
+        variant("Sand", "S", NAVY_A),
+      ];
+      for (const color of ["Navy", "Sand"]) {
+        expect(
+          resolveCardImages({ ...base, selectedColor: color, variants })
+        ).toEqual({ primary: NAVY_A, secondary: NAVY_B });
+      }
+    });
+
+    it("still resolves a single-color product", () => {
+      // One color claiming the image is indistinguishable from inheritance, but
+      // the resulting photo is the same either way.
+      const result = resolveCardImages({
+        selectedColor: "Navy",
+        variants: [variant("Navy", "S", NAVY_A), variant("Navy", "M", NAVY_A)],
+        galleryUrls: GALLERY,
+        imageUrl: NAVY_A,
+        secondaryImageUrl: NAVY_B,
+      });
+      expect(result).toEqual({ primary: NAVY_A, secondary: NAVY_B });
+    });
+
+    it("treats an inherited next image as a hover partner, not a boundary", () => {
+      // HERO is claimed by both colors, so it opens no color group and stays
+      // eligible as Navy's cross-fade partner.
+      const result = resolveCardImages({
+        selectedColor: "Navy",
+        variants: [
+          variant("Navy", "S", NAVY_A),
+          variant("Navy", "M", HERO),
+          variant("Sand", "S", HERO),
+        ],
+        galleryUrls: [NAVY_A, HERO],
+        imageUrl: NAVY_A,
+        secondaryImageUrl: HERO,
+      });
+      expect(result).toEqual({ primary: NAVY_A, secondary: HERO });
+    });
+  });
+
   it("ignores a size whose value collides with the selected color", () => {
     // A size literally named "Sand" must not be mistaken for the color.
     const odd: CardVariant = {
@@ -142,6 +212,47 @@ describe("resolveCardImages", () => {
       variants: [odd, variant("Sand", "S", SAND_A)],
     });
     expect(result.primary).toBe(SAND_A);
+  });
+});
+
+describe("cardPricing", () => {
+  const flat = { minVariantPrice: 50, maxVariantPrice: 50 };
+  const ranged = { minVariantPrice: 50, maxVariantPrice: 80 };
+
+  it("shows a price range without a strikethrough", () => {
+    // The range max is not a discount; striking it through invents one.
+    const result = cardPricing(ranged, null, "GBP");
+    expect(result.rangePrice).toBe("£80.00");
+    expect(result.strikePrice).toBeNull();
+    expect(result.salePercent).toBe(0);
+  });
+
+  it("strikes through a genuine compare-at price", () => {
+    const result = cardPricing(flat, 100, "GBP");
+    expect(result.strikePrice).toBe("£100.00");
+    expect(result.rangePrice).toBeNull();
+    expect(result.salePercent).toBe(50);
+  });
+
+  it("prefers the discount over the range when both apply", () => {
+    const result = cardPricing(ranged, 100, "GBP");
+    expect(result.strikePrice).toBe("£100.00");
+    expect(result.rangePrice).toBeNull();
+  });
+
+  it("ignores a compare-at price at or below the current price", () => {
+    for (const compareAt of [50, 40]) {
+      const result = cardPricing(flat, compareAt, "GBP");
+      expect(result.strikePrice).toBeNull();
+      expect(result.salePercent).toBe(0);
+    }
+  });
+
+  it("shows neither figure for a flat, undiscounted price", () => {
+    const result = cardPricing(flat, null, "GBP");
+    expect(result.price).toBe("£50.00");
+    expect(result.strikePrice).toBeNull();
+    expect(result.rangePrice).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/shopify/options.ts
+++ b/apps/web/src/lib/shopify/options.ts
@@ -13,20 +13,31 @@ export function getOptionType(name: string): "color" | "size" | "default" {
   return "default";
 }
 
-/** Splits product options into color and size value lists for card display. */
+/**
+ * Splits product options into color and size value lists for card display.
+ * The option names come back too — the PDP keys its search params by the
+ * literal Shopify option name, so links need "Colour" when that's what the
+ * product uses.
+ */
 export function getCardOptions(options: ShopifyProductOption[]): {
   colors: string[];
   sizes: string[];
+  colorOptionName?: string;
+  sizeOptionName?: string;
 } {
   let colors: string[] = [];
   let sizes: string[] = [];
+  let colorOptionName: string | undefined;
+  let sizeOptionName: string | undefined;
   for (const option of options) {
     const type = getOptionType(option.name);
     if (type === "color") {
       colors = option.values;
+      colorOptionName = option.name;
     } else if (type === "size") {
       sizes = option.values;
+      sizeOptionName = option.name;
     }
   }
-  return { colors, sizes };
+  return { colors, sizes, colorOptionName, sizeOptionName };
 }

--- a/apps/web/src/lib/shopify/product-card.ts
+++ b/apps/web/src/lib/shopify/product-card.ts
@@ -5,12 +5,13 @@ import type {
   StockStatus,
 } from "@/components/product/product-card";
 import { getColorHex } from "./color";
+import { formatMoney } from "./money";
 import { getCardOptions, getOptionType } from "./options";
 import {
+  type CardImageFields,
   type CardSourceProduct,
   type Connection,
   LOW_STOCK_THRESHOLD,
-  type ShopifyImage,
 } from "./types";
 
 /** Derives the merch badge from Shopify product tags. */
@@ -28,11 +29,56 @@ export function badgeFromTags(tags: string[]): MerchBadge | null {
  * differs from the featured image (else the 2nd image), or null.
  */
 export function secondaryImageUrl(
-  images: Connection<ShopifyImage> | undefined,
+  images: Connection<CardImageFields> | undefined,
   featuredUrl: string | null
 ): string | null {
   const urls = (images?.edges ?? []).map((edge) => edge.node.url);
   return urls.find((url) => url !== featuredUrl) ?? urls[1] ?? null;
+}
+
+function money(amount: number, currencyCode: string) {
+  return formatMoney({ amount: String(amount), currencyCode });
+}
+
+/**
+ * Card price figures. `strikePrice` is a real discount and renders struck
+ * through; `rangePrice` is only the top of a variant price range and must not,
+ * or it reads as a discount that isn't there.
+ */
+export function cardPricing(
+  priceRange: ProductCardProps["priceRange"],
+  compareAtPrice: number | null | undefined,
+  code: string
+): {
+  price: string;
+  salePercent: number;
+  strikePrice: string | null;
+  rangePrice: string | null;
+} {
+  const price = money(priceRange.minVariantPrice, code);
+  const showRange = priceRange.minVariantPrice !== priceRange.maxVariantPrice;
+
+  const onSale =
+    typeof compareAtPrice === "number" &&
+    compareAtPrice > priceRange.minVariantPrice;
+  if (!(onSale && compareAtPrice)) {
+    return {
+      price,
+      salePercent: 0,
+      strikePrice: null,
+      rangePrice: showRange ? money(priceRange.maxVariantPrice, code) : null,
+    };
+  }
+
+  // A discount takes precedence over the range: showing both reads as noise.
+  return {
+    price,
+    salePercent: Math.round(
+      ((compareAtPrice - priceRange.minVariantPrice) / compareAtPrice) * 100
+    ),
+    strikePrice: money(compareAtPrice, code),
+    rangePrice: null,
+  };
 }
 
 /** The variant's value for the color- or size-typed option, if it has one. */
@@ -61,10 +107,45 @@ export function findCardVariant(
 }
 
 /**
+ * Colors using each variant image.
+ *
+ * Storefront's `ProductVariant.image` "falls back to the product image if no
+ * image is available", so a color with no photo of its own silently reports
+ * some other color's. An image claimed by more than one color is that fallback
+ * rather than a photo of any one color, which is how we tell the two apart.
+ */
+function colorsByImage(variants: CardVariant[]): Map<string, Set<string>> {
+  const colors = new Map<string, Set<string>>();
+  for (const variant of variants) {
+    const url = variant.image?.url;
+    const color = optionValue(variant, "color");
+    if (!(url && color)) continue;
+    const seen = colors.get(url);
+    if (seen) {
+      seen.add(color);
+    } else {
+      colors.set(url, new Set([color]));
+    }
+  }
+  return colors;
+}
+
+/** Whether this image belongs to exactly one color — i.e. is not inherited. */
+function isSpecificTo(
+  colors: Map<string, Set<string>>,
+  url: string,
+  color: string
+) {
+  const claimed = colors.get(url);
+  return claimed?.size === 1 && claimed.has(color);
+}
+
+/**
  * Card images for the current color: that color's variant photo, plus the next
  * gallery image as the hover cross-fade partner (Shopify orders product images
  * in per-color groups). Falls back to the product-level pair whenever the color
- * has no photo of its own.
+ * has no photo of its own — including when it merely inherited the product
+ * image, which the Storefront API reports indistinguishably from a real one.
  */
 export function resolveCardImages({
   selectedColor,
@@ -82,10 +163,10 @@ export function resolveCardImages({
   const fallback = { primary: imageUrl, secondary: productSecondary ?? null };
   if (!selectedColor || !variants || variants.length === 0) return fallback;
 
-  const primary = variants.find(
-    (variant) =>
-      optionValue(variant, "color") === selectedColor && variant.image?.url
-  )?.image?.url;
+  const colors = colorsByImage(variants);
+  const primary = variants
+    .map((variant) => variant.image?.url)
+    .find((url) => url && isSpecificTo(colors, url, selectedColor));
   if (!primary) return fallback;
 
   const gallery = galleryUrls ?? [];
@@ -97,12 +178,10 @@ export function resolveCardImages({
   if (!next) return { primary, secondary: null };
 
   // If the next image opens another color's group, this color has a single
-  // photo — better no cross-fade than fading into the wrong color.
-  const opensAnotherColor = variants.some(
-    (variant) =>
-      variant.image?.url === next &&
-      optionValue(variant, "color") !== selectedColor
-  );
+  // photo — better no cross-fade than fading into the wrong color. An inherited
+  // image marks no group, so it stays eligible as the hover partner.
+  const claimed = colors.get(next);
+  const opensAnotherColor = claimed?.size === 1 && !claimed.has(selectedColor);
   return { primary, secondary: opensAnotherColor ? null : next };
 }
 

--- a/apps/web/src/lib/shopify/product-card.ts
+++ b/apps/web/src/lib/shopify/product-card.ts
@@ -1,14 +1,15 @@
 import type {
+  CardVariant,
   MerchBadge,
   ProductCardProps,
   StockStatus,
 } from "@/components/product/product-card";
 import { getColorHex } from "./color";
-import { getCardOptions } from "./options";
+import { getCardOptions, getOptionType } from "./options";
 import {
+  type CardSourceProduct,
   type Connection,
   LOW_STOCK_THRESHOLD,
-  type ShopifyCollectionProduct,
   type ShopifyImage,
 } from "./types";
 
@@ -34,26 +35,120 @@ export function secondaryImageUrl(
   return urls.find((url) => url !== featuredUrl) ?? urls[1] ?? null;
 }
 
-/** Maps a Storefront collection product to canonical ProductCard props. */
-export function collectionProductToCardProps(
-  product: ShopifyCollectionProduct
-): ProductCardProps {
-  const variant = product.variants.edges[0]?.node;
+/** The variant's value for the color- or size-typed option, if it has one. */
+function optionValue(variant: CardVariant, type: "color" | "size") {
+  return variant.selectedOptions.find(
+    (option) => getOptionType(option.name) === type
+  )?.value;
+}
 
-  let stockStatus: StockStatus = null;
-  if (!variant?.availableForSale) {
-    stockStatus = "out";
-  } else if (
+/**
+ * Finds the variant matching the card's color and size selection. Matches per
+ * option type rather than on bare values, so a color and a size sharing a value
+ * string can't cross-match.
+ */
+export function findCardVariant(
+  variants: CardVariant[] | undefined,
+  color: string | undefined,
+  size: string | undefined
+): CardVariant | undefined {
+  if (!variants || variants.length === 0) return undefined;
+  return variants.find(
+    (variant) =>
+      (!color || optionValue(variant, "color") === color) &&
+      (!size || optionValue(variant, "size") === size)
+  );
+}
+
+/**
+ * Card images for the current color: that color's variant photo, plus the next
+ * gallery image as the hover cross-fade partner (Shopify orders product images
+ * in per-color groups). Falls back to the product-level pair whenever the color
+ * has no photo of its own.
+ */
+export function resolveCardImages({
+  selectedColor,
+  variants,
+  galleryUrls,
+  imageUrl,
+  secondaryImageUrl: productSecondary,
+}: {
+  selectedColor: string | undefined;
+  variants: CardVariant[] | undefined;
+  galleryUrls: string[] | undefined;
+  imageUrl: string | null;
+  secondaryImageUrl: string | null | undefined;
+}): { primary: string | null; secondary: string | null } {
+  const fallback = { primary: imageUrl, secondary: productSecondary ?? null };
+  if (!selectedColor || !variants || variants.length === 0) return fallback;
+
+  const primary = variants.find(
+    (variant) =>
+      optionValue(variant, "color") === selectedColor && variant.image?.url
+  )?.image?.url;
+  if (!primary) return fallback;
+
+  const gallery = galleryUrls ?? [];
+  const index = gallery.indexOf(primary);
+  // Variant photo outside the fetched gallery window — keep the product hover.
+  if (index === -1) return { primary, secondary: fallback.secondary };
+
+  const next = gallery[index + 1] ?? null;
+  if (!next) return { primary, secondary: null };
+
+  // If the next image opens another color's group, this color has a single
+  // photo — better no cross-fade than fading into the wrong color.
+  const opensAnotherColor = variants.some(
+    (variant) =>
+      variant.image?.url === next &&
+      optionValue(variant, "color") !== selectedColor
+  );
+  return { primary, secondary: opensAnotherColor ? null : next };
+}
+
+/**
+ * Stock badge for a card. Prefers the product-level fields the featured/card
+ * queries select, falling back to the first variant's inventory.
+ */
+function cardStockStatus(product: CardSourceProduct): StockStatus {
+  if (product.availableForSale === false) return "out";
+  if (product.totalInventory !== undefined) {
+    if (
+      product.totalInventory !== null &&
+      product.totalInventory > 0 &&
+      product.totalInventory <= LOW_STOCK_THRESHOLD
+    ) {
+      return "low";
+    }
+    return null;
+  }
+
+  const variant = product.variants.edges[0]?.node;
+  if (!variant?.availableForSale) return "out";
+  if (
     variant.quantityAvailable !== null &&
     variant.quantityAvailable > 0 &&
     variant.quantityAvailable <= LOW_STOCK_THRESHOLD
   ) {
-    stockStatus = "low";
+    return "low";
   }
+  return null;
+}
 
+/** Maps a Storefront collection product to canonical ProductCard props. */
+export function collectionProductToCardProps(
+  product: CardSourceProduct
+): ProductCardProps {
   const compareAt = product.compareAtPriceRange?.minVariantPrice.amount;
-  const { colors: colorNames, sizes } = getCardOptions(product.options ?? []);
+  const {
+    colors: colorNames,
+    sizes,
+    colorOptionName,
+  } = getCardOptions(product.options ?? []);
   const colors = colorNames.map((name) => ({ name, hex: getColorHex(name) }));
+  const galleryUrls = (product.images?.edges ?? []).map(
+    (edge) => edge.node.url
+  );
 
   return {
     slug: product.handle,
@@ -70,13 +165,15 @@ export function collectionProductToCardProps(
       maxVariantPrice: Number(product.priceRange.maxVariantPrice.amount),
     },
     compareAtPrice: compareAt ? Number(compareAt) : null,
-    stockStatus,
+    stockStatus: cardStockStatus(product),
     badge: badgeFromTags(product.tags ?? []),
     variantName: colorNames[0] ?? null,
     colors,
     selectedColor: colorNames[0],
+    colorOptionName,
     sizes,
     selectedSize: sizes[0],
     variants: (product.variants?.edges ?? []).map((edge) => edge.node),
+    galleryUrls,
   };
 }

--- a/apps/web/src/lib/shopify/queries.ts
+++ b/apps/web/src/lib/shopify/queries.ts
@@ -26,6 +26,36 @@ const VARIANT_FRAGMENT = /* graphql */ `
   }
 `;
 
+/**
+ * Variant selection shared by every product-card query. `image` is what lets a
+ * card swap its photo when a color swatch is picked.
+ */
+const CARD_VARIANT_FIELDS = /* graphql */ `
+  id
+  availableForSale
+  quantityAvailable
+  price {
+    amount
+    currencyCode
+  }
+  selectedOptions {
+    name
+    value
+  }
+  image {
+    url
+    altText
+    width
+    height
+  }
+`;
+
+/**
+ * Product gallery window for cards. Wide enough to locate the image following a
+ * variant's image, which the card uses as the hover cross-fade partner.
+ */
+const CARD_GALLERY_SIZE = 20;
+
 const PRODUCT_FIELDS_FRAGMENT = /* graphql */ `
   fragment ProductFields on Product {
     id
@@ -151,7 +181,7 @@ export const COLLECTION_QUERY = /* graphql */ `
               width
               height
             }
-            images(first: 2) {
+            images(first: ${CARD_GALLERY_SIZE}) {
               edges {
                 node {
                   url
@@ -180,17 +210,7 @@ export const COLLECTION_QUERY = /* graphql */ `
             variants(first: 100) {
               edges {
                 node {
-                  id
-                  availableForSale
-                  quantityAvailable
-                  price {
-                    amount
-                    currencyCode
-                  }
-                  selectedOptions {
-                    name
-                    value
-                  }
+                  ${CARD_VARIANT_FIELDS}
                 }
               }
             }
@@ -258,17 +278,7 @@ const PRODUCT_CARD_FIELDS = /* graphql */ `
   variants(first: 100) {
     edges {
       node {
-        id
-        availableForSale
-        quantityAvailable
-        price {
-          amount
-          currencyCode
-        }
-        selectedOptions {
-          name
-          value
-        }
+        ${CARD_VARIANT_FIELDS}
       }
     }
   }
@@ -278,7 +288,7 @@ const PRODUCT_CARD_FIELDS = /* graphql */ `
     width
     height
   }
-  images(first: 2) {
+  images(first: ${CARD_GALLERY_SIZE}) {
     edges {
       node {
         url
@@ -330,6 +340,14 @@ export const PRODUCTS_BY_HANDLES_QUERY = /* graphql */ `
   }
 `;
 
+export const RELATED_PRODUCTS_QUERY = /* graphql */ `
+  query RelatedProducts($productId: ID!) {
+    productRecommendations(productId: $productId) {
+      ${PRODUCT_CARD_FIELDS}
+    }
+  }
+`;
+
 export const ALL_COLLECTIONS_QUERY = /* graphql */ `
   query AllCollections($first: Int!) {
     collections(first: $first) {
@@ -374,7 +392,7 @@ export const SEARCH_PRODUCTS_QUERY = /* graphql */ `
               width
               height
             }
-            images(first: 2) {
+            images(first: ${CARD_GALLERY_SIZE}) {
               edges {
                 node {
                   url
@@ -397,17 +415,7 @@ export const SEARCH_PRODUCTS_QUERY = /* graphql */ `
             variants(first: 100) {
               edges {
                 node {
-                  id
-                  availableForSale
-                  quantityAvailable
-                  price {
-                    amount
-                    currencyCode
-                  }
-                  selectedOptions {
-                    name
-                    value
-                  }
+                  ${CARD_VARIANT_FIELDS}
                 }
               }
             }
@@ -445,7 +453,7 @@ export const PREDICTIVE_SEARCH_QUERY = /* graphql */ `
           width
           height
         }
-        images(first: 2) {
+        images(first: ${CARD_GALLERY_SIZE}) {
           edges {
             node {
               url
@@ -474,17 +482,7 @@ export const PREDICTIVE_SEARCH_QUERY = /* graphql */ `
         variants(first: 100) {
           edges {
             node {
-              id
-              availableForSale
-              quantityAvailable
-              price {
-                amount
-                currencyCode
-              }
-              selectedOptions {
-                name
-                value
-              }
+              ${CARD_VARIANT_FIELDS}
             }
           }
         }
@@ -529,7 +527,7 @@ export const BEST_SELLING_PRODUCTS_QUERY = /* graphql */ `
             width
             height
           }
-          images(first: 2) {
+          images(first: ${CARD_GALLERY_SIZE}) {
             edges {
               node {
                 url
@@ -558,17 +556,7 @@ export const BEST_SELLING_PRODUCTS_QUERY = /* graphql */ `
           variants(first: 100) {
             edges {
               node {
-                id
-                availableForSale
-                quantityAvailable
-                price {
-                  amount
-                  currencyCode
-                }
-                selectedOptions {
-                  name
-                  value
-                }
+                ${CARD_VARIANT_FIELDS}
               }
             }
           }
@@ -644,7 +632,7 @@ export const PRODUCT_BY_HANDLE_QUERY = /* graphql */ `
         width
         height
       }
-      images(first: 8) {
+      images(first: ${CARD_GALLERY_SIZE}) {
         edges {
           node {
             url
@@ -667,17 +655,7 @@ export const PRODUCT_BY_HANDLE_QUERY = /* graphql */ `
       variants(first: 100) {
         edges {
           node {
-            id
-            availableForSale
-            quantityAvailable
-            price {
-              amount
-              currencyCode
-            }
-            selectedOptions {
-              name
-              value
-            }
+            ${CARD_VARIANT_FIELDS}
           }
         }
       }

--- a/apps/web/src/lib/shopify/queries.ts
+++ b/apps/web/src/lib/shopify/queries.ts
@@ -409,6 +409,12 @@ export const SEARCH_PRODUCTS_QUERY = /* graphql */ `
                 currencyCode
               }
             }
+            compareAtPriceRange {
+              minVariantPrice {
+                amount
+                currencyCode
+              }
+            }
             variants(first: 100) {
               edges {
                 node {
@@ -636,6 +642,12 @@ export const PRODUCT_BY_HANDLE_QUERY = /* graphql */ `
           currencyCode
         }
         maxVariantPrice {
+          amount
+          currencyCode
+        }
+      }
+      compareAtPriceRange {
+        minVariantPrice {
           amount
           currencyCode
         }

--- a/apps/web/src/lib/shopify/queries.ts
+++ b/apps/web/src/lib/shopify/queries.ts
@@ -44,9 +44,6 @@ const CARD_VARIANT_FIELDS = /* graphql */ `
   }
   image {
     url
-    altText
-    width
-    height
   }
 `;
 
@@ -55,6 +52,15 @@ const CARD_VARIANT_FIELDS = /* graphql */ `
  * variant's image, which the card uses as the hover cross-fade partner.
  */
 const CARD_GALLERY_SIZE = 20;
+
+/**
+ * Card image selection. Cards render with `fill` and alt from the product
+ * title, so `url` is the only field any card path reads — worth keeping narrow
+ * given the gallery window above multiplies it by 20 per product.
+ */
+const CARD_IMAGE_FIELDS = /* graphql */ `
+  url
+`;
 
 const PRODUCT_FIELDS_FRAGMENT = /* graphql */ `
   fragment ProductFields on Product {
@@ -184,10 +190,7 @@ export const COLLECTION_QUERY = /* graphql */ `
             images(first: ${CARD_GALLERY_SIZE}) {
               edges {
                 node {
-                  url
-                  altText
-                  width
-                  height
+          ${CARD_IMAGE_FIELDS}
                 }
               }
             }
@@ -291,10 +294,7 @@ const PRODUCT_CARD_FIELDS = /* graphql */ `
   images(first: ${CARD_GALLERY_SIZE}) {
     edges {
       node {
-        url
-        altText
-        width
-        height
+          ${CARD_IMAGE_FIELDS}
       }
     }
   }
@@ -395,10 +395,7 @@ export const SEARCH_PRODUCTS_QUERY = /* graphql */ `
             images(first: ${CARD_GALLERY_SIZE}) {
               edges {
                 node {
-                  url
-                  altText
-                  width
-                  height
+          ${CARD_IMAGE_FIELDS}
                 }
               }
             }
@@ -456,10 +453,7 @@ export const PREDICTIVE_SEARCH_QUERY = /* graphql */ `
         images(first: ${CARD_GALLERY_SIZE}) {
           edges {
             node {
-              url
-              altText
-              width
-              height
+          ${CARD_IMAGE_FIELDS}
             }
           }
         }
@@ -530,10 +524,7 @@ export const BEST_SELLING_PRODUCTS_QUERY = /* graphql */ `
           images(first: ${CARD_GALLERY_SIZE}) {
             edges {
               node {
-                url
-                altText
-                width
-                height
+          ${CARD_IMAGE_FIELDS}
               }
             }
           }
@@ -635,10 +626,7 @@ export const PRODUCT_BY_HANDLE_QUERY = /* graphql */ `
       images(first: ${CARD_GALLERY_SIZE}) {
         edges {
           node {
-            url
-            altText
-            width
-            height
+          ${CARD_IMAGE_FIELDS}
           }
         }
       }

--- a/apps/web/src/lib/shopify/types.ts
+++ b/apps/web/src/lib/shopify/types.ts
@@ -69,7 +69,7 @@ export type ShopifyCollectionProduct = {
   tags: string[];
   options: ShopifyProductOption[];
   featuredImage: ShopifyImage | null;
-  /** First two images, used for the hover cross-fade on product cards. */
+  /** Product gallery, used to derive the product card's hover cross-fade. */
   images?: Connection<ShopifyImage>;
   priceRange: {
     minVariantPrice: MoneyV2;
@@ -78,16 +78,36 @@ export type ShopifyCollectionProduct = {
   compareAtPriceRange?: {
     minVariantPrice: MoneyV2;
   };
-  variants: Connection<
-    Pick<
-      ShopifyVariant,
-      | "id"
-      | "availableForSale"
-      | "quantityAvailable"
-      | "price"
-      | "selectedOptions"
-    >
-  >;
+  variants: Connection<CardVariantFields>;
+};
+
+/**
+ * Variant fields every product-card query selects. `image` drives the card's
+ * photo swap when a color swatch is picked.
+ */
+export type CardVariantFields = Pick<
+  ShopifyVariant,
+  | "id"
+  | "availableForSale"
+  | "quantityAvailable"
+  | "price"
+  | "selectedOptions"
+  | "image"
+>;
+
+/**
+ * Minimum product shape `collectionProductToCardProps` accepts, covering both
+ * collection products and the product-level stock fields carried by featured
+ * products.
+ */
+export type CardSourceProduct = Omit<
+  ShopifyCollectionProduct,
+  "productType"
+> & {
+  productType?: string;
+  /** Product-level stock, selected only by the featured/card-fields queries. */
+  availableForSale?: boolean;
+  totalInventory?: number | null;
 };
 
 export type ShopifyFilterValue = {
@@ -238,18 +258,9 @@ export type FeaturedProduct = {
   options: ShopifyProductOption[];
   availableForSale: boolean;
   totalInventory: number | null;
-  variants: Connection<
-    Pick<
-      ShopifyVariant,
-      | "id"
-      | "availableForSale"
-      | "quantityAvailable"
-      | "price"
-      | "selectedOptions"
-    >
-  >;
+  variants: Connection<CardVariantFields>;
   featuredImage: ShopifyImage | null;
-  /** First two images, used for the hover cross-fade on product cards. */
+  /** Product gallery, used to derive the product card's hover cross-fade. */
   images?: Connection<ShopifyImage>;
   priceRange: {
     minVariantPrice: MoneyV2;

--- a/apps/web/src/lib/shopify/types.ts
+++ b/apps/web/src/lib/shopify/types.ts
@@ -70,7 +70,7 @@ export type ShopifyCollectionProduct = {
   options: ShopifyProductOption[];
   featuredImage: ShopifyImage | null;
   /** Product gallery, used to derive the product card's hover cross-fade. */
-  images?: Connection<ShopifyImage>;
+  images?: Connection<CardImageFields>;
   priceRange: {
     minVariantPrice: MoneyV2;
     maxVariantPrice: MoneyV2;
@@ -82,18 +82,19 @@ export type ShopifyCollectionProduct = {
 };
 
 /**
+ * Image fields card queries select. Cards render with `fill` and take alt text
+ * from the product title, so `url` is all any card path reads.
+ */
+export type CardImageFields = Pick<ShopifyImage, "url">;
+
+/**
  * Variant fields every product-card query selects. `image` drives the card's
  * photo swap when a color swatch is picked.
  */
 export type CardVariantFields = Pick<
   ShopifyVariant,
-  | "id"
-  | "availableForSale"
-  | "quantityAvailable"
-  | "price"
-  | "selectedOptions"
-  | "image"
->;
+  "id" | "availableForSale" | "quantityAvailable" | "price" | "selectedOptions"
+> & { image: CardImageFields | null };
 
 /**
  * Minimum product shape `collectionProductToCardProps` accepts, covering both
@@ -261,7 +262,7 @@ export type FeaturedProduct = {
   variants: Connection<CardVariantFields>;
   featuredImage: ShopifyImage | null;
   /** Product gallery, used to derive the product card's hover cross-fade. */
-  images?: Connection<ShopifyImage>;
+  images?: Connection<CardImageFields>;
   priceRange: {
     minVariantPrice: MoneyV2;
     maxVariantPrice: MoneyV2;


### PR DESCRIPTION
## Problem / Intent

Selecting a color swatch on a product card (collection grid, search results, related products, featured products, cart recommendations) changed the subtitle text and the add-to-cart variant, but the photo stayed on the product's `featuredImage`. The PDP has always done this correctly — this was a parity gap between the two surfaces.

Two independent causes:

1. No card-feeding GraphQL query requested `variants { image }`. Only the PDP's `VariantFields` fragment selected it, so the card had no per-color photo available to show.
2. `CardImage` read static props that were never re-derived from the selected color.

## Approach

- Extracted the variant selection duplicated verbatim across six queries into a shared `CARD_VARIANT_FIELDS` const, now including `image`, and widened the card gallery window from 2 to 20 images.
- Added `resolveCardImages`, which maps the selected color to its variant photo and takes the next gallery image as the hover cross-fade partner. When a color has only one photo it returns `null` rather than fading into the next color's group.
- Replaced the card's local `resolveVariant` with `findCardVariant`, matching per option type instead of on bare option values — previously a size and color sharing a value string could cross-match.
- Carried the selected color into the PDP link via the existing-but-unused `buildVariantUrl`, so the choice survives navigation.
- Moved `RELATED_PRODUCTS_QUERY` onto the shared `PRODUCT_CARD_FIELDS`. It had omitted `price` on variants while being typed as having one, so hover add-to-cart was passing `price: undefined` into `buildLineMetadata`.
- Routed `featured-products` and `cart-recommendations` through `collectionProductToCardProps` instead of hand-rolling card props, so all five card surfaces stay in sync.

Two known limitations worth a reviewer's attention: the hover-partner rule assumes Shopify orders gallery images in per-color groups (true for this catalog; a store that interleaves images would get a wrong-color hover), and the collection query payload grew from 2 to 20 images per product — only `.url` is consumed, so those selections can be trimmed if size becomes a concern.

## How to test

The seed catalog has exactly one multi-color product: **Aster Denim Coach Jacket** (`Indigo Rinse`, `Warm Stone`).

1. `pnpm dev:web`, then open `/collections/all-products` and find the Aster Denim Coach Jacket card.
2. Click the **Warm Stone** swatch. The card photo should switch from `...indigo-rinse-01.png` to `...warm-stone-01.png`, and the subtitle should change to "Warm Stone".
3. Hover the card. The cross-fade should go to `...warm-stone-02.png` — the same color, not back to an indigo shot.
4. Click back to **Indigo Rinse** and confirm both images revert.
5. Click through to the PDP. The URL should be `/products/aster-denim-coach-jacket?Color=Warm+Stone` and the PDP should open on Warm Stone with the gallery scrolled to it. (Note `+` is the encoded space and decodes correctly.)
6. Repeat steps 2-3 on the other card surfaces, since each uses a different query: `/search?q=jacket`, the search drawer empty state, related products at the bottom of any PDP, the cart recommendations rail (open the cart), and the homepage featured-products block.
7. Confirm the hover add-to-cart on **related products** works — it exercises the newly added `price` field.

Automated: `pnpm check-types`, `pnpm lint`, `pnpm format:check`, and `cd apps/web && npx vitest run` (74 tests, 15 of them new for `resolveCardImages` and `findCardVariant`).


## PREVIEW 

https://github.com/user-attachments/assets/a142e099-39ee-4c77-bb85-f263eb3ef874


---
Ticket: [ROB-2414](https://linear.app/issue/ROB-2414)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product cards now update images when a color is selected, including improved hover-image behavior.
  * Product links can preserve the selected color variant.
  * Variant selection and pricing displays are more consistent across featured, related, and cart recommendation products.
  * Stock availability is reflected more accurately on product cards.

* **Bug Fixes**
  * Improved handling of missing images, unavailable variants, and color or size combinations.

* **Tests**
  * Added coverage for variant matching and color-based image selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->