### PR TITLE
ROB-2441: feat: new full-bleed hero center treatment

### DIFF
--- a/apps/web/src/components/sections/hero.tsx
+++ b/apps/web/src/components/sections/hero.tsx
@@ -27,17 +27,70 @@ type HeroBlockProps = {
 };
 
 /**
- * Maps the Sanity content-position choice to alignment classes. `text` aligns
- * the actual text lines; `selfX` (auto margins) positions the block and the
- * w-fit buttons, which text-align alone can't move.
+ * Maps the Sanity content-position choice to its full overlay treatment.
+ *
+ * `text` aligns the actual text lines; `selfX` (auto margins) positions the
+ * block and the w-fit buttons, which text-align alone can't move.
+ *
+ * bottomCenter is the "campaign" lockup: large white copy centred over the
+ * image, per the SS26 design. The left/right positions keep the original
+ * small dark-on-light treatment.
+ *
+ * `mix-blend-plus-lighter` on the white copy matches the design and softens
+ * the glyph edges additively against the photo; it needs the `isolate` on the
+ * hero wrapper so the blend group can't escape past the image.
  */
 const CONTENT_POSITION: Record<
   HeroContentPosition,
-  { text: string; selfX: string }
+  {
+    text: string;
+    selfX: string;
+    scrim: string;
+    pad: string;
+    block: string;
+    lockup: string;
+    title: string;
+    link: string;
+    richText: string;
+  }
 > = {
-  bottomLeft: { text: "text-left", selfX: "mr-auto" },
-  bottomCenter: { text: "text-center", selfX: "mx-auto" },
-  bottomRight: { text: "text-right", selfX: "ml-auto" },
+  bottomLeft: {
+    text: "text-left",
+    selfX: "mr-auto",
+    scrim: "from-white/90 via-white/60 to-transparent lg:hidden",
+    pad: "pb-8 md:pb-12",
+    block: "max-w-md text-zinc-900",
+    lockup: "text-2xl leading-tight",
+    title: "",
+    link: "",
+    richText: "text-sm [&_p]:text-zinc-800!",
+  },
+  bottomCenter: {
+    text: "text-center",
+    selfX: "mx-auto",
+    // Mobile-only dark scrim: the tighter crop there can put white copy over
+    // light imagery, so it needs the backing. Desktop matches the design
+    // exactly — no scrim, the art direction keeps the copy over dark pixels.
+    scrim: "from-black/60 via-black/25 to-transparent lg:hidden",
+    pad: "pb-8",
+    block: "text-white",
+    lockup: "",
+    title:
+      "font-semibold text-3xl leading-[1.16] tracking-tighter mix-blend-plus-lighter md:text-5xl",
+    link: "text-base leading-6 tracking-[0.24px] mix-blend-plus-lighter",
+    richText: "text-sm [&_p]:text-white!",
+  },
+  bottomRight: {
+    text: "text-right",
+    selfX: "ml-auto",
+    scrim: "from-white/90 via-white/60 to-transparent lg:hidden",
+    pad: "pb-8 md:pb-12",
+    block: "max-w-md text-zinc-900",
+    lockup: "text-2xl leading-tight",
+    title: "",
+    link: "",
+    richText: "text-sm [&_p]:text-zinc-800!",
+  },
 };
 
 export function HeroBlock(props: HeroBlockProps) {
@@ -107,7 +160,7 @@ function FullBleedHero({
     CONTENT_POSITION.bottomLeft;
   return (
     <section className="relative" id="hero">
-      <div className="card-surface relative h-[92dvh] min-h-125 w-full overflow-hidden">
+      <div className="card-surface relative isolate h-[92dvh] min-h-125 w-full overflow-hidden">
         {image && (
           <SanityImage
             className="absolute inset-0 h-full min-h-full w-full rounded-none object-cover"
@@ -119,28 +172,36 @@ function FullBleedHero({
           />
         )}
 
-        {/* Bottom scrim so dark promo text stays legible over light imagery */}
+        {/* Bottom scrim so the promo text stays legible over any imagery */}
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 bg-linear-to-t from-white/90 via-white/60 to-transparent lg:hidden"
+          className={cn(
+            "pointer-events-none absolute inset-x-0 bottom-0 h-1/2 bg-linear-to-t",
+            pos.scrim
+          )}
         />
 
         {/* Promo text overlaid along the bottom (position set in Sanity) */}
         <div className="absolute inset-x-0 bottom-0">
-          <div className="site-container pb-8 md:pb-12">
+          <div className={cn("site-container", pos.pad)}>
             <div
               className={cn(
-                "flex w-full max-w-md flex-col gap-2 font-medium text-zinc-900",
+                "flex w-full flex-col gap-2 font-medium",
+                pos.block,
                 pos.text,
                 pos.selfX
               )}
             >
-              <div className="text-2xl leading-tight">
-                {title && <p>{title}</p>}
+              <div className={pos.lockup}>
+                {title && <p className={pos.title}>{title}</p>}
                 {buttons?.map((button) =>
                   button.href ? (
                     <Link
-                      className={cn("block w-fit hover:underline", pos.selfX)}
+                      className={cn(
+                        "block w-fit hover:underline",
+                        pos.link,
+                        pos.selfX
+                      )}
                       href={button.href}
                       key={button._key}
                       target={button.openInNewTab ? "_blank" : "_self"}
@@ -151,10 +212,7 @@ function FullBleedHero({
                 )}
               </div>
               {richText && (
-                <RichText
-                  className="text-sm [&_p]:text-zinc-800!"
-                  richText={richText}
-                />
+                <RichText className={pos.richText} richText={richText} />
               )}
             </div>
           </div>

--- a/apps/web/src/components/sections/hero.tsx
+++ b/apps/web/src/components/sections/hero.tsx
@@ -78,7 +78,10 @@ const CONTENT_POSITION: Record<
     title:
       "font-semibold text-3xl leading-[1.16] tracking-tighter mix-blend-plus-lighter md:text-5xl",
     link: "text-base leading-6 tracking-[0.24px] mix-blend-plus-lighter",
-    richText: "text-sm [&_p]:text-white!",
+    // RichText hard-codes text-foreground on headings, lists, strong, code and
+    // links as well as paragraphs, so whiten every descendant - anything less
+    // leaves bold or linked words near-black over the image.
+    richText: "text-sm marker:text-white! [&_*]:text-white!",
   },
   bottomRight: {
     text: "text-right",


### PR DESCRIPTION
## Problem / Intent

The hero design has been updated. The full-bleed hero rendered all three `contentPosition` options with one shared treatment — small dark `text-zinc-900` copy clamped to `max-w-md` over a white scrim. The new design reworks the **centered** position into a large white campaign lockup.

Figma: [Turbo Start — Hero](https://www.figma.com/design/EKMxkt0NhxINPIDPWjCJsv/Turbo-Start?node-id=3482-719)

## Approach

`CONTENT_POSITION` in `hero.tsx` now carries the full per-position treatment (scrim, padding, block, lockup, title, link, rich text) rather than alignment alone. `FullBleedHero` reads its classes from that map, so `bottomCenter` gets the new lockup while `bottomLeft` / `bottomRight` keep their existing look byte-for-byte.

- Title: 48px semibold white, `leading-[1.16]`, `tracking-tighter`, scaling to `text-3xl` on mobile
- Link: 16px medium, `tracking-[0.24px]`, directly beneath the title with no gap
- White copy uses `mix-blend-plus-lighter` per the design. This needs `isolate` on the hero wrapper so the blend group cannot escape past the image — the only change touching all three variants
- Mobile gets a dark scrim behind the copy, since the tighter crop can put white text over light imagery. Desktop matches the design exactly with no scrim
- No schema, GROQ, or generated-type changes — `contentPosition` already existed and flows through the `...` spread in `heroBlock`

## How to test

1. `pnpm dev:web`, open http://localhost:3000
2. In Studio, set the home page hero to `style: fullBleed` and `contentPosition: bottomCenter`
3. At a 1440px viewport, compare against the Figma frame — title should read 48px semibold white, the link 16px directly beneath with no gap, the lockup centered and ~32px off the bottom (80px tall total)
4. Resize below `lg` — a dark scrim should fade in behind the copy. Above `lg` there should be no scrim
5. At ~375px, confirm the title drops to 30px with no horizontal overflow
6. Switch `contentPosition` to `bottomLeft` and `bottomRight` — both must look exactly as they do on `main` (dark copy, white mobile-only scrim, `max-w-md`)
7. `pnpm check-types` and `pnpm lint`

Worth a reviewer's eye: on desktop the center variant has no scrim, so legibility depends on merchandisers art-directing the bottom-center of the image dark, as the comp does. A light-background hero would lose the copy at `lg`.


## PREVIEW 
<img width="4018" height="2446" alt="CleanShot 2026-07-28 at 09 59 05@2x" src="https://github.com/user-attachments/assets/a02ae59b-e2a9-4c2e-9ced-94a3ae6c35b5" />

---
Ticket: [ROB-2441](https://linear.app/roboto/issue/ROB-2441)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved full-bleed hero layouts with more flexible content positioning.
  * Updated overlay styling, spacing, text sizing, link appearance, and rich text presentation based on the selected position.
  * Enhanced scrim behavior for better readability across hero content placements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->