### PR TITLE
perf:fix pdp lightbox refetching the raw shopify master on first open

### DIFF
--- a/apps/web/src/components/product/product-gallery.tsx
+++ b/apps/web/src/components/product/product-gallery.tsx
@@ -271,6 +271,12 @@ export function ProductGallery({
   const [lightboxIndex, setLightboxIndex] = useState(0);
   // Source rect captured at click time — reliable, unlike resolving it later.
   const [sourceRect, setSourceRect] = useState<DOMRect | null>(null);
+  // Likewise for the source URL. Tagged with the index it was captured for so
+  // arrow navigation inside the lightbox can't render a stale image's URL.
+  const [sourceSrc, setSourceSrc] = useState<{
+    index: number;
+    src: string;
+  } | null>(null);
 
   // On-page image elements per `${view}:${index}`, so the lightbox can zoom
   // out of / back into whichever view is currently visible.
@@ -308,7 +314,9 @@ export function ProductGallery({
   }
 
   const openLightbox = (index: number) => {
+    const src = getSourceSrc(index);
     setSourceRect(getSourceRect(index));
+    setSourceSrc(src ? { index, src } : null);
     setLightboxIndex(index);
     setLightboxOpen(true);
   };
@@ -336,6 +344,7 @@ export function ProductGallery({
         onOpenChange={setLightboxOpen}
         open={lightboxOpen}
         sourceRect={sourceRect}
+        sourceSrc={sourceSrc}
       />
     </>
   );

--- a/apps/web/src/components/product/product-lightbox.tsx
+++ b/apps/web/src/components/product/product-lightbox.tsx
@@ -15,6 +15,7 @@ import {
   useState,
 } from "react";
 
+import { shopifyFullscreenURL } from "@/lib/shopify/image-loader";
 import type { ShopifyImage } from "@/lib/shopify/types";
 
 type ProductLightboxProps = {
@@ -28,9 +29,14 @@ type ProductLightboxProps = {
   /** Resolves the current on-page source rect (for the close FLIP). */
   getSourceRect: (index: number) => DOMRect | null;
   /**
-   * Resolves the optimized URL the on-page `next/image` already downloaded, so
-   * the fullscreen `<img>` reuses that cached resource (instant, no new fetch).
-   * `null` when the image isn't loaded on-page.
+   * The optimized URL the on-page `next/image` had already downloaded when the
+   * lightbox was opened, so the fullscreen `<img>` reuses that cached resource
+   * (instant, no new fetch). Tagged with its index; `null` when unavailable.
+   */
+  sourceSrc: { index: number; src: string } | null;
+  /**
+   * Resolves that same URL live, for images reached by arrow navigation rather
+   * than by the click that opened the lightbox.
    */
   getSourceSrc: (index: number) => string | null;
 };
@@ -57,6 +63,7 @@ export function ProductLightbox({
   onOpenChange,
   onIndexChange,
   sourceRect,
+  sourceSrc,
   getSourceRect,
   getSourceSrc,
 }: ProductLightboxProps) {
@@ -79,16 +86,31 @@ export function ProductLightbox({
   const openedFlip = useRef(false);
 
   const current = images[index];
+  const [displaySrc, setDisplaySrc] = useState<string | undefined>(undefined);
 
   // Reuse the exact optimized URL the on-page gallery already downloaded so the
-  // fullscreen image is an instant cache hit with no new fetch. Falls back to
-  // the raw Shopify URL only when the image isn't loaded on-page (e.g. an
-  // arrow-navigated image that was still lazy).
-  const displaySrc = current ? (getSourceSrc(index) ?? current.url) : undefined;
+  // fullscreen image is an instant cache hit with no new fetch.
+  //
+  // This must be an effect, not a render-phase expression. Reading `currentSrc`
+  // off the on-page <img> during render is impure, and the React Compiler
+  // memoizes it on deps that never change between mount and open (`images`,
+  // `index`, and the stable parent callbacks — not `open`). That froze the
+  // value to the mount-time result, when the gallery's refs were still empty,
+  // so every first open fetched the multi-MB Shopify master instead.
+  //
+  // Falls back to a bounded transform only when the image isn't loaded on-page
+  // (e.g. an arrow-navigated image that was still lazy) — never the master.
+  useLayoutEffect(() => {
+    if (!(open && current)) return;
+    const cached =
+      sourceSrc?.index === index ? sourceSrc.src : getSourceSrc(index);
+    setDisplaySrc(cached ?? shopifyFullscreenURL(current.url));
+  }, [open, index, current, sourceSrc, getSourceSrc]);
 
   // Zoom the image out of its on-page source. Runs once the lightbox image has
-  // laid out — usually frame 1, since `displaySrc` reuses the gallery's cached
-  // resource; the raw-URL fallback can still lag, hence the polling below.
+  // laid out — frame 1, since the <img> carries intrinsic width/height so its
+  // box is measurable before the resource arrives; the poll below is a safety
+  // net for images whose dimensions are missing.
   const runOpenFlip = () => {
     if (!open || openedFlip.current) return;
     const img = imgRef.current;
@@ -295,6 +317,8 @@ export function ProductLightbox({
                 alt={current.altText ?? "Product image"}
                 className="block max-h-[calc(100vh-4rem)] w-auto max-w-[92vw] select-none object-contain"
                 draggable={false}
+                fetchPriority="high"
+                height={current.height}
                 ref={imgRef}
                 src={displaySrc}
                 style={{
@@ -302,6 +326,7 @@ export function ProductLightbox({
                   transformOrigin: "center center",
                   transition: panning ? "none" : "transform 200ms ease",
                 }}
+                width={current.width}
               />
             </button>
           )}

--- a/apps/web/src/components/product/shopify-image.tsx
+++ b/apps/web/src/components/product/shopify-image.tsx
@@ -3,6 +3,7 @@
 import Image, { type ImageProps } from "next/image";
 
 import {
+  isShopifyUrl,
   shopifyBlurDataURL,
   shopifyImageLoader,
 } from "@/lib/shopify/image-loader";
@@ -19,7 +20,10 @@ export function ShopifyImage({
   blurDataURL,
   ...props
 }: ImageProps) {
-  const isShopify = typeof src === "string" && src.includes("cdn.shopify.com");
+  // Share one predicate with the loader. If this said "Shopify" and the loader
+  // disagreed, the loader would return every `srcset` URL untouched and all
+  // resizing would silently stop.
+  const isShopify = typeof src === "string" && isShopifyUrl(src);
 
   return (
     <Image

--- a/apps/web/src/lib/shopify/image-loader.ts
+++ b/apps/web/src/lib/shopify/image-loader.ts
@@ -35,6 +35,24 @@ export function shopifyImageLoader({
 }
 
 /**
+ * A bounded Shopify variant sized for the fullscreen lightbox. Used only when
+ * the lightbox can't reuse the resource the on-page gallery already downloaded
+ * (e.g. an arrow-navigated image that was still lazy). Bare Shopify `url`
+ * values are the untransformed master — often several MB — so never hand one
+ * straight to an `<img>`.
+ */
+export function shopifyFullscreenURL(src: string): string {
+  if (!isShopifyUrl(src)) {
+    return src;
+  }
+
+  const url = new URL(src);
+  url.searchParams.set("width", "2048");
+  url.searchParams.set("quality", "85");
+  return url.toString();
+}
+
+/**
  * A tiny, low-quality Shopify variant of the same image, used as the
  * `blurDataURL` for `placeholder="blur"`. This renders a blurry preview
  * instantly and sharpens to the full image as it loads (the "blur-up" effect).

--- a/apps/web/src/lib/shopify/image-loader.ts
+++ b/apps/web/src/lib/shopify/image-loader.ts
@@ -2,8 +2,24 @@ import type { ImageLoaderProps } from "next/image";
 
 const SHOPIFY_CDN_HOST = "cdn.shopify.com";
 
-function isShopifyUrl(src: string): boolean {
-  return src.includes(SHOPIFY_CDN_HOST);
+/**
+ * Whether `src` is an absolute URL served by the Shopify CDN.
+ *
+ * Matches on the parsed hostname rather than a substring, so values that merely
+ * mention the host — `https://example.com/?ref=cdn.shopify.com`, or a lookalike
+ * like `cdn.shopify.com.example.com` — are correctly rejected. Unparseable and
+ * relative values return `false`, which is what makes the `new URL(src)` calls
+ * in the transforms below safe.
+ *
+ * Exact equality is deliberate: `next.config.ts` pins `remotePatterns` to this
+ * one hostname, so a looser test would rewrite URLs Next would then refuse.
+ */
+export function isShopifyUrl(src: string): boolean {
+  try {
+    return new URL(src).hostname === SHOPIFY_CDN_HOST;
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
The lightbox was meant to reuse the optimized URL the on-page gallery had already downloaded (5fd3442), but that never ran. It read the DOM during render:

  const displaySrc = current ? (getSourceSrc(index) ?? current.url) : undefined;

With reactCompiler on, the compiler memoizes that on [current, getSourceSrc, index] — `open` is not a dep, and none of the three change between mount and the click. So it evaluated once at mount, when the gallery's ref map was still empty (ref callbacks fire at commit, after that render), got null, and froze on the current.url fallback — the untransformed Shopify master, often several MB.

Every first open therefore fetched a resource the page had never touched. The second open was fast only because that master was now in the HTTP cache. Invisible in dev, since `unoptimized: NODE_ENV === "development"` makes next/image emit the master there too, so both sides shared a URL.

- capture the source URL in the click handler, tagged with its index, the way sourceRect already was; arrow navigation still reads live
- resolve displaySrc in a useLayoutEffect keyed on [open, index, ...] instead of in the render body
- add a bounded shopifyFullscreenURL (width 2048, q85) so the still-reachable fallback is never the master
- give the fullscreen <img> its intrinsic width/height, so the box is measurable on frame 1 and the open FLIP fires immediately instead of the rAF poll spinning up to 1000ms against a 0x0 box while the backdrop had already faded in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved product image lightboxes by reusing already-loaded optimized images when available.
  * Added higher-quality fullscreen image rendering with faster loading.
  * Added consistent fullscreen image sizing for a smoother viewing experience.
* **Bug Fixes**
  * Prevented fullscreen views from falling back to unoptimized image URLs when an optimized version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->