### PR TITLE
fix: close the search drawer when a result is opened

### DIFF
--- a/apps/web/src/components/collection/collection-card.tsx
+++ b/apps/web/src/components/collection/collection-card.tsx
@@ -6,17 +6,21 @@ export type CollectionCardProps = {
   handle: string;
   title: string;
   imageUrl: string | null;
+  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  replace?: boolean;
 };
 
 export function CollectionCard({
   handle,
   title,
   imageUrl,
+  replace,
 }: CollectionCardProps) {
   return (
     <Link
       className="group block overflow-hidden"
       href={`/collections/${handle}`}
+      replace={replace}
     >
       <div className="card-surface relative aspect-56/75 overflow-hidden">
         {imageUrl ? (

--- a/apps/web/src/components/collection/collection-card.tsx
+++ b/apps/web/src/components/collection/collection-card.tsx
@@ -6,7 +6,7 @@ export type CollectionCardProps = {
   handle: string;
   title: string;
   imageUrl: string | null;
-  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  /** Forwarded to `next/link`: replace the current history entry, don't push. */
   replace?: boolean;
 };
 

--- a/apps/web/src/components/product/product-card.tsx
+++ b/apps/web/src/components/product/product-card.tsx
@@ -60,6 +60,8 @@ export type ProductCardProps = {
   /** Ordered gallery URLs; locates the hover partner for a color's photo. */
   galleryUrls?: string[];
   mini?: boolean;
+  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  replace?: boolean;
 };
 
 const BADGE_LABEL: Record<MerchBadge, string> = {
@@ -76,6 +78,7 @@ function ProductCardMini({
   price,
   strikePrice,
   rangePrice,
+  replace,
 }: {
   slug: string;
   title: string;
@@ -83,11 +86,13 @@ function ProductCardMini({
   price: string;
   strikePrice: string | null;
   rangePrice: string | null;
+  replace?: boolean;
 }) {
   return (
     <Link
       className="flex items-center gap-3 p-2 transition-colors hover:bg-accent"
       href={`/products/${slug}`}
+      replace={replace}
     >
       {imageUrl ? (
         <div className="card-surface relative size-12 shrink-0 overflow-hidden border">
@@ -369,6 +374,7 @@ export function ProductCard({
   variants,
   galleryUrls,
   mini,
+  replace,
 }: ProductCardProps) {
   const [selectedColor, setSelectedColor] = useState(initialColor);
   const [selectedSize, setSelectedSize] = useState(initialSize);
@@ -386,6 +392,7 @@ export function ProductCard({
         imageUrl={imageUrl}
         price={price}
         rangePrice={rangePrice}
+        replace={replace}
         slug={slug}
         strikePrice={strikePrice}
         title={title}
@@ -414,6 +421,7 @@ export function ProductCard({
           aria-label={title}
           className="relative block size-full"
           href={href}
+          replace={replace}
         >
           <CardImage
             imageUrl={primary}
@@ -449,7 +457,7 @@ export function ProductCard({
       </div>
 
       <div className="mt-2 px-1 flex items-start justify-between gap-2">
-        <Link className="flex flex-col gap-2" href={href}>
+        <Link className="flex flex-col gap-2" href={href} replace={replace}>
           <div className="flex flex-col gap-0.5">
             <h3 className="font-medium text-base text-foreground leading-tight">
               {title}

--- a/apps/web/src/components/product/product-card.tsx
+++ b/apps/web/src/components/product/product-card.tsx
@@ -60,7 +60,7 @@ export type ProductCardProps = {
   /** Ordered gallery URLs; locates the hover partner for a color's photo. */
   galleryUrls?: string[];
   mini?: boolean;
-  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  /** Forwarded to `next/link`: replace the current history entry, don't push. */
   replace?: boolean;
 };
 

--- a/apps/web/src/components/search/paths.ts
+++ b/apps/web/src/components/search/paths.ts
@@ -1,0 +1,27 @@
+export const SEARCH_PATH = "/search";
+
+const QUERY_PARAM = "q";
+
+/** The search term carried by a `location.search` string, trimmed. */
+export function readSearchQuery(search: string): string {
+  return new URLSearchParams(search).get(QUERY_PARAM)?.trim() ?? "";
+}
+
+/**
+ * `SEARCH_PATH` with `q` set to `query` (or removed when it is empty), keeping
+ * every other param in `search` intact — callers pass `window.location.search`,
+ * which can carry utm_* and anything else the visitor arrived with.
+ */
+export function searchUrlWithQuery(query: string, search: string): string {
+  const params = new URLSearchParams(search);
+  const trimmed = query.trim();
+
+  if (trimmed) {
+    params.set(QUERY_PARAM, trimmed);
+  } else {
+    params.delete(QUERY_PARAM);
+  }
+
+  const rest = params.toString();
+  return rest ? `${SEARCH_PATH}?${rest}` : SEARCH_PATH;
+}

--- a/apps/web/src/components/search/search-empty-state.tsx
+++ b/apps/web/src/components/search/search-empty-state.tsx
@@ -9,7 +9,7 @@ import { useSearchDefaults } from "./use-search-defaults";
 type SearchEmptyStateProps = {
   /** Runs a search for the given term (mirrors the Related chips). */
   onSelectTerm: (term: string) => void;
-  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  /** Forwarded to `next/link`: replace the current history entry, don't push. */
   replace?: boolean;
 };
 

--- a/apps/web/src/components/search/search-empty-state.tsx
+++ b/apps/web/src/components/search/search-empty-state.tsx
@@ -9,9 +9,14 @@ import { useSearchDefaults } from "./use-search-defaults";
 type SearchEmptyStateProps = {
   /** Runs a search for the given term (mirrors the Related chips). */
   onSelectTerm: (term: string) => void;
+  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  replace?: boolean;
 };
 
-export function SearchEmptyState({ onSelectTerm }: SearchEmptyStateProps) {
+export function SearchEmptyState({
+  onSelectTerm,
+  replace,
+}: SearchEmptyStateProps) {
   const { collections, bestSellers, isLoading } = useSearchDefaults();
 
   return (
@@ -42,12 +47,15 @@ export function SearchEmptyState({ onSelectTerm }: SearchEmptyStateProps) {
             Best Sellers
           </h2>
           <Button asChild size="sm">
-            <Link href="/collections">Shop All</Link>
+            <Link href="/collections" replace={replace}>
+              Shop All
+            </Link>
           </Button>
         </div>
         <SearchProductGrid
           isLoading={isLoading}
           products={bestSellers}
+          replace={replace}
           skeletonCount={4}
         />
       </section>

--- a/apps/web/src/components/search/search-modal.tsx
+++ b/apps/web/src/components/search/search-modal.tsx
@@ -6,35 +6,71 @@ import {
   SheetDescription,
   SheetTitle,
 } from "@workspace/ui/components/sheet";
-import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { SearchPanel } from "./search-panel";
 
+const SEARCH_PATH = "/search";
+
 export function SearchModal({ initialQuery = "" }: { initialQuery?: string }) {
   const router = useRouter();
-  const [open, setOpen] = useState(true);
+  const onSearchRoute = usePathname() === SEARCH_PATH;
 
-  // Drive the close through local state so the Sheet's slide-out animation
-  // plays immediately (instant feedback). The intercepted route is only popped
-  // once the exit animation finishes, via onAnimationEnd below.
-  const handleClose = useCallback(() => setOpen(false), []);
+  const [open, setOpen] = useState(true);
+  // Radix keeps the node mounted through the exit animation, so we need a
+  // second flag to drop the subtree once that has played — otherwise the panel
+  // keeps its react-query subscription and the typed term leaks into the next
+  // open (initialQuery can't reset a useState that never unmounted).
+  const [rendered, setRendered] = useState(true);
+  // Which of the two closes is in flight. A dismiss (Close / Esc / overlay) has
+  // to pop the intercepted route; a result click has already navigated, and
+  // popping there lands on the page the drawer was opened over.
+  const dismissing = useRef(false);
+
+  // A soft nav does NOT clear this slot: Next keeps an unmatched parallel
+  // route's last render, and @modal/default.tsx only applies on a hard load. So
+  // clicking a result leaves the drawer sitting over the new page unless we
+  // notice the route ourselves. Mirrored both ways — leaving /search animates
+  // out, coming back re-opens.
+  useEffect(() => {
+    if (onSearchRoute) {
+      setRendered(true);
+    }
+    setOpen(onSearchRoute);
+  }, [onSearchRoute]);
+
+  const dismiss = useCallback(() => {
+    dismissing.current = true;
+    setOpen(false);
+  }, []);
+
+  if (!rendered) {
+    return null;
+  }
 
   return (
     <Sheet
       onOpenChange={(next) => {
         if (!next) {
-          handleClose();
+          dismiss();
         }
       }}
       open={open}
     >
       <SheetContent
         className="h-dvh w-full gap-0 border-none p-0 data-[state=open]:duration-300 sm:max-w-none"
-        onAnimationEnd={() => {
-          if (!open) {
+        onAnimationEnd={(event) => {
+          // animationend bubbles, and it also fires for the enter animation —
+          // neither is our exit finishing.
+          if (open || event.target !== event.currentTarget) {
+            return;
+          }
+          if (dismissing.current) {
+            dismissing.current = false;
             router.back();
           }
+          setRendered(false);
         }}
         showCloseButton={false}
         side="bottom"
@@ -46,7 +82,8 @@ export function SearchModal({ initialQuery = "" }: { initialQuery?: string }) {
 
         <SearchPanel
           initialQuery={initialQuery}
-          onClose={handleClose}
+          onClose={dismiss}
+          replace
           scrollable
         />
       </SheetContent>

--- a/apps/web/src/components/search/search-modal.tsx
+++ b/apps/web/src/components/search/search-modal.tsx
@@ -9,24 +9,35 @@ import {
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { SEARCH_PATH } from "./paths";
 import { SearchPanel } from "./search-panel";
 
-const SEARCH_PATH = "/search";
+/**
+ * Fires when Radix unmounts the sheet — i.e. once the exit animation has
+ * finished, or immediately if there is none. Cheaper and far more robust than
+ * watching `animationend` ourselves: Presence already handles zero-duration
+ * animations, `display: none`, and cancellation.
+ */
+function ExitSignal({ onExit }: { onExit: () => void }) {
+  useEffect(() => () => onExit(), [onExit]);
+  return null;
+}
 
 export function SearchModal({ initialQuery = "" }: { initialQuery?: string }) {
   const router = useRouter();
   const onSearchRoute = usePathname() === SEARCH_PATH;
 
   const [open, setOpen] = useState(true);
-  // Radix keeps the node mounted through the exit animation, so we need a
-  // second flag to drop the subtree once that has played — otherwise the panel
-  // keeps its react-query subscription and the typed term leaks into the next
-  // open (initialQuery can't reset a useState that never unmounted).
-  const [rendered, setRendered] = useState(true);
-  // Which of the two closes is in flight. A dismiss (Close / Esc / overlay) has
-  // to pop the intercepted route; a result click has already navigated, and
-  // popping there lands on the page the drawer was opened over.
+  // Set while a dismiss (Close / Esc / overlay) is animating out, so the exit
+  // knows to pop the intercepted route. A result click must NOT set it: that
+  // has already navigated, and popping would land on the page the drawer was
+  // opened over.
   const dismissing = useRef(false);
+  // Set from the moment a result is clicked until the new route commits. Next
+  // transitions cannot be cancelled, so a dismiss during that window would pop
+  // the entry out from under the pending navigation and strand the user on the
+  // page they searched from — with neither the product nor the search.
+  const navigating = useRef(false);
 
   // A soft nav does NOT clear this slot: Next keeps an unmatched parallel
   // route's last render, and @modal/default.tsx only applies on a hard load. So
@@ -35,19 +46,29 @@ export function SearchModal({ initialQuery = "" }: { initialQuery?: string }) {
   // out, coming back re-opens.
   useEffect(() => {
     if (onSearchRoute) {
-      setRendered(true);
+      // Both latches are per-close. Clearing them here covers the exit that
+      // never completed because the drawer was re-opened mid-animation.
+      dismissing.current = false;
+      navigating.current = false;
     }
     setOpen(onSearchRoute);
   }, [onSearchRoute]);
 
   const dismiss = useCallback(() => {
+    if (navigating.current) {
+      return;
+    }
     dismissing.current = true;
     setOpen(false);
   }, []);
 
-  if (!rendered) {
-    return null;
-  }
+  const handleExit = useCallback(() => {
+    if (!dismissing.current) {
+      return;
+    }
+    dismissing.current = false;
+    router.back();
+  }, [router]);
 
   return (
     <Sheet
@@ -60,21 +81,20 @@ export function SearchModal({ initialQuery = "" }: { initialQuery?: string }) {
     >
       <SheetContent
         className="h-dvh w-full gap-0 border-none p-0 data-[state=open]:duration-300 sm:max-w-none"
-        onAnimationEnd={(event) => {
-          // animationend bubbles, and it also fires for the enter animation —
-          // neither is our exit finishing.
-          if (open || event.target !== event.currentTarget) {
+        onClickCapture={(event) => {
+          // Modified clicks open a new tab and leave this one on /search, so
+          // they must not arm the guard.
+          if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
             return;
           }
-          if (dismissing.current) {
-            dismissing.current = false;
-            router.back();
+          if ((event.target as HTMLElement).closest?.("a[href]")) {
+            navigating.current = true;
           }
-          setRendered(false);
         }}
         showCloseButton={false}
         side="bottom"
       >
+        <ExitSignal onExit={handleExit} />
         <SheetTitle className="sr-only">Search</SheetTitle>
         <SheetDescription className="sr-only">
           Search products and collections

--- a/apps/web/src/components/search/search-page-content.tsx
+++ b/apps/web/src/components/search/search-page-content.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { useDebounce } from "@/hooks/use-debounce";
 import type { ShopifyCollectionProduct } from "@/lib/shopify/types";
+import { readSearchQuery, searchUrlWithQuery } from "./paths";
 import { SearchEmptyState } from "./search-empty-state";
 import { SearchProductGrid } from "./search-product-grid";
 
@@ -47,10 +48,17 @@ export function SearchPageContent({
   // Keep the address bar in sync WITHOUT a router navigation — a client nav to
   // /search would re-trigger the intercepting route and open the drawer.
   useEffect(() => {
-    const url = trimmed
-      ? `/search?q=${encodeURIComponent(trimmed)}`
-      : "/search";
-    window.history.replaceState(null, "", url);
+    // Skip identical writes, and rebuild from the live URL rather than from
+    // scratch: this page is a share/ad landing target, so it routinely arrives
+    // carrying utm_* params that a from-scratch URL would silently drop.
+    if (readSearchQuery(window.location.search) === trimmed) {
+      return;
+    }
+    window.history.replaceState(
+      null,
+      "",
+      searchUrlWithQuery(trimmed, window.location.search)
+    );
   }, [trimmed]);
 
   const { data, isLoading } = useQuery({

--- a/apps/web/src/components/search/search-panel.tsx
+++ b/apps/web/src/components/search/search-panel.tsx
@@ -3,13 +3,12 @@
 import { cn } from "@workspace/ui/lib/utils";
 import { X } from "lucide-react";
 import { usePathname } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import { SEARCH_PATH, readSearchQuery, searchUrlWithQuery } from "./paths";
 import { SearchEmptyState } from "./search-empty-state";
 import { SearchResults } from "./search-results";
 import { useProductSearch } from "./use-product-search";
-
-const SEARCH_PATH = "/search";
 
 type SearchPanelProps = {
   initialQuery?: string;
@@ -32,6 +31,20 @@ export function SearchPanel({
   replace,
 }: SearchPanelProps) {
   const pathname = usePathname();
+  // The URL can carry a ?q= this render never saw: the sync below uses
+  // replaceState, which does not re-run the server component, so a Back or
+  // Forward into that entry restores the URL but replays a tree still seeded
+  // with the original (empty) initialQuery. Read the live URL once at mount to
+  // close that gap — safe on the server, where it resolves to initialQuery, and
+  // safe against hydration, because a real render always sees the same URL the
+  // server did; only client-side history replays diverge.
+  const [seedQuery] = useState(
+    () =>
+      initialQuery ||
+      (typeof window === "undefined"
+        ? ""
+        : readSearchQuery(window.location.search))
+  );
   const {
     query,
     setQuery,
@@ -41,22 +54,28 @@ export function SearchPanel({
     related,
     isSearching,
     hasQuery,
-  } = useProductSearch(initialQuery);
+  } = useProductSearch(seedQuery);
 
   // Keep the URL in sync with the query so a refresh / shared link lands on the
   // /search page with the same term. history.replaceState, not router.replace,
   // for the same reason as search-page-content: a router nav here costs an RSC
-  // round-trip per keystroke, and a debounce landing just after the user opened
-  // a result would drag the URL back off that product.
+  // round-trip per keystroke. The pathname check keeps a late debounce from
+  // rewriting the URL after the user has already navigated on to a product.
   useEffect(() => {
     if (pathname !== SEARCH_PATH) {
       return;
     }
     const trimmed = debouncedQuery.trim();
+    // Writing an identical URL is not free: on the mount that follows a
+    // Back/Forward the state is still catching up, and an unconditional write
+    // would strip the ?q= the entry was restored with.
+    if (readSearchQuery(window.location.search) === trimmed) {
+      return;
+    }
     window.history.replaceState(
       null,
       "",
-      trimmed ? `/search?q=${encodeURIComponent(trimmed)}` : SEARCH_PATH
+      searchUrlWithQuery(trimmed, window.location.search)
     );
   }, [debouncedQuery, pathname]);
 

--- a/apps/web/src/components/search/search-panel.tsx
+++ b/apps/web/src/components/search/search-panel.tsx
@@ -2,12 +2,14 @@
 
 import { cn } from "@workspace/ui/lib/utils";
 import { X } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useEffect, useRef } from "react";
 
 import { SearchEmptyState } from "./search-empty-state";
 import { SearchResults } from "./search-results";
 import { useProductSearch } from "./use-product-search";
+
+const SEARCH_PATH = "/search";
 
 type SearchPanelProps = {
   initialQuery?: string;
@@ -15,14 +17,21 @@ type SearchPanelProps = {
   onClose?: () => void;
   /** Fill the parent height with an internal scroll area (used inside the drawer). */
   scrollable?: boolean;
+  /**
+   * Replace the current history entry when a result is opened instead of
+   * pushing. Set by the drawer so Back from a product goes to the page the
+   * search was opened over, not back into the search.
+   */
+  replace?: boolean;
 };
 
 export function SearchPanel({
   initialQuery = "",
   onClose,
   scrollable = false,
+  replace,
 }: SearchPanelProps) {
-  const router = useRouter();
+  const pathname = usePathname();
   const {
     query,
     setQuery,
@@ -35,14 +44,21 @@ export function SearchPanel({
   } = useProductSearch(initialQuery);
 
   // Keep the URL in sync with the query so a refresh / shared link lands on the
-  // /search page with the same term. `replace` avoids polluting history.
+  // /search page with the same term. history.replaceState, not router.replace,
+  // for the same reason as search-page-content: a router nav here costs an RSC
+  // round-trip per keystroke, and a debounce landing just after the user opened
+  // a result would drag the URL back off that product.
   useEffect(() => {
+    if (pathname !== SEARCH_PATH) {
+      return;
+    }
     const trimmed = debouncedQuery.trim();
-    router.replace(
-      trimmed ? `/search?q=${encodeURIComponent(trimmed)}` : "/search",
-      { scroll: false }
+    window.history.replaceState(
+      null,
+      "",
+      trimmed ? `/search?q=${encodeURIComponent(trimmed)}` : SEARCH_PATH
     );
-  }, [debouncedQuery, router]);
+  }, [debouncedQuery, pathname]);
 
   // Focus the input when the panel mounts.
   const inputRef = useRef<HTMLInputElement>(null);
@@ -83,9 +99,10 @@ export function SearchPanel({
             onSelectTerm={setQuery}
             products={products}
             related={related}
+            replace={replace}
           />
         ) : (
-          <SearchEmptyState onSelectTerm={setQuery} />
+          <SearchEmptyState onSelectTerm={setQuery} replace={replace} />
         )}
       </div>
     </div>

--- a/apps/web/src/components/search/search-product-grid.tsx
+++ b/apps/web/src/components/search/search-product-grid.tsx
@@ -12,6 +12,8 @@ type SearchProductGridProps = {
   products: ShopifyCollectionProduct[];
   isLoading: boolean;
   skeletonCount?: number;
+  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  replace?: boolean;
 };
 
 /** Shared 4-col ProductCard grid used by both the empty and active states. */
@@ -19,6 +21,7 @@ export function SearchProductGrid({
   products,
   isLoading,
   skeletonCount = DEFAULT_SKELETON_COUNT,
+  replace,
 }: SearchProductGridProps) {
   if (isLoading) {
     return (
@@ -45,6 +48,7 @@ export function SearchProductGrid({
         <ProductCard
           key={product.id}
           {...collectionProductToCardProps(product)}
+          replace={replace}
         />
       ))}
     </div>

--- a/apps/web/src/components/search/search-product-grid.tsx
+++ b/apps/web/src/components/search/search-product-grid.tsx
@@ -12,7 +12,7 @@ type SearchProductGridProps = {
   products: ShopifyCollectionProduct[];
   isLoading: boolean;
   skeletonCount?: number;
-  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  /** Forwarded to `next/link`: replace the current history entry, don't push. */
   replace?: boolean;
 };
 

--- a/apps/web/src/components/search/search-results.tsx
+++ b/apps/web/src/components/search/search-results.tsx
@@ -20,14 +20,18 @@ type SearchResultsProps = {
   collections: ShopifyCollectionLite[];
   isSearching: boolean;
   onSelectTerm: (term: string) => void;
+  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  replace?: boolean;
 };
 
 function CollectionsGrid({
   collections,
   isLoading,
+  replace,
 }: {
   collections: ShopifyCollectionLite[];
   isLoading: boolean;
+  replace?: boolean;
 }) {
   if (isLoading) {
     return (
@@ -52,6 +56,7 @@ function CollectionsGrid({
         <CollectionCard
           key={collection.id}
           {...shopifyCollectionToCardProps(collection)}
+          replace={replace}
         />
       ))}
     </div>
@@ -64,6 +69,7 @@ export function SearchResults({
   collections,
   isSearching,
   onSelectTerm,
+  replace,
 }: SearchResultsProps) {
   const [tab, setTab] = useState<Tab>("products");
 
@@ -117,9 +123,17 @@ export function SearchResults({
       </div>
 
       {tab === "products" ? (
-        <SearchProductGrid isLoading={isSearching} products={products} />
+        <SearchProductGrid
+          isLoading={isSearching}
+          products={products}
+          replace={replace}
+        />
       ) : (
-        <CollectionsGrid collections={collections} isLoading={isSearching} />
+        <CollectionsGrid
+          collections={collections}
+          isLoading={isSearching}
+          replace={replace}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/search/search-results.tsx
+++ b/apps/web/src/components/search/search-results.tsx
@@ -20,7 +20,7 @@ type SearchResultsProps = {
   collections: ShopifyCollectionLite[];
   isSearching: boolean;
   onSelectTerm: (term: string) => void;
-  /** Replace the current history entry instead of pushing (see SearchPanel). */
+  /** Forwarded to `next/link`: replace the current history entry, don't push. */
   replace?: boolean;
 };
 

--- a/apps/web/src/components/search/search-toggle.tsx
+++ b/apps/web/src/components/search/search-toggle.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { SearchIcon } from "../icons";
+import { SEARCH_PATH } from "./paths";
 
 const TOGGLE_CLASS =
   "inline-flex items-center justify-center transition-colors hover:text-foreground";
@@ -14,7 +15,7 @@ export function SearchToggle() {
   // On the search page itself, focus the existing input instead of navigating
   // to /search again — a client nav would re-trigger the intercepting route and
   // pop the drawer over the page.
-  if (pathname === "/search") {
+  if (pathname === SEARCH_PATH) {
     return (
       <button
         aria-label="Search"
@@ -30,7 +31,7 @@ export function SearchToggle() {
   }
 
   return (
-    <Link aria-label="Search" className={TOGGLE_CLASS} href="/search">
+    <Link aria-label="Search" className={TOGGLE_CLASS} href={SEARCH_PATH}>
       <SearchIcon className="size-5" />
     </Link>
   );


### PR DESCRIPTION
## Problem / Intent

Clicking a product or collection in the search drawer navigated the URL but left the drawer on screen. Closing from there landed on the page you were on *before* the search while the address bar still read `/search?q=…`, and the navbar search icon was dead until a full reload.

## Approach

Next keeps an unmatched parallel-route slot's last render across a soft nav (`@modal/default.tsx` only applies on a hard load), so `SearchModal` stayed mounted over the new page. `onAnimationEnd`'s `router.back()` then popped to the `/search` entry — whose `children` slot holds the page the search was opened over — instead of dismissing an overlay.

- `SearchModal` mirrors the route into `open` both ways, and separates a user dismiss (must pop the intercepted route) from a navigation close (must not). Drops the subtree after the exit so the panel stops fetching and the typed term can't leak into the next open.
- `SearchPanel` syncs the query with `history.replaceState` instead of `router.replace`, matching `search-page-content` — no RSC round-trip per keystroke, and no debounce dragging the URL back off a product.
- Results replace the current history entry, so Back from a product returns to the page the search was opened over.

## How to test

1. Go to `/collections/shirts`, click the navbar search icon, type `shirt`.
2. Click a result — the drawer should slide out **over** the product page (~300ms), not linger.
3. Press Back — you should land on `/collections/shirts`, not back in the search.
4. Reopen the drawer — the input should be empty, not still holding `shirt`.
5. Open the drawer and hit Close or `Esc` — you should return to the page underneath, with the search icon still working.
6. Repeat step 2 with the Collections tab.
7. Load `/search?q=shirt` directly — the standalone page renders with no drawer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved search navigation so closing the search panel returns to the previous page smoothly.
  * Search URLs now stay synchronized with queries without unnecessary page navigation.
  * Added consistent history-replacement behavior when navigating to products and collections from search results.
  * Search panels now fully reset after closing, ensuring a clean state when reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->