### PR TITLE
fix: card surface in dark mode — gradient and crossfade bleed

### DIFF
--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -112,7 +112,9 @@ const BAR_BG = "#fafafa";
 const TEXT_DARK = "#18181b";
 
 // Matches the product card's `.card-surface` (--card-surface-from/to in
-// packages/ui globals) — used behind transparent/missing product images.
+// packages/ui globals) — used behind transparent/missing product images. Those
+// tokens are oklch(); the hex here is the equivalent and has to stay hex because
+// satori (next/og) can't parse oklch() and would drop the gradient entirely.
 const CARD_GRADIENT = "linear-gradient(to bottom, #c1c6c8, #e2e5e9)";
 
 // Brand marks are rendered as inline-SVG data URIs via <img>. Satori reliably

--- a/apps/web/src/components/product/product-card.tsx
+++ b/apps/web/src/components/product/product-card.tsx
@@ -397,27 +397,37 @@ function CardImage({
 
   return (
     <>
+      {/* The outgoing image does NOT fade. Two layers cross-fading in opposite
+        * directions only cover `a + (1-a)²` of the box, which bottoms out at
+        * 75%, so the card-surface gradient behind them bled through at the
+        * midpoint — a pale band across the card, obvious in dark mode where
+        * that gradient stays light. Instead the incoming image carries its own
+        * copy of the gradient (below) and fades in over this one, so coverage
+        * is 100% the whole way and both layers composite against an identical
+        * backdrop. Costs nothing in time — no delay, no longer duration. */}
       <Image
         alt={title}
         className={cn(
           "object-cover",
-          // Morph on hover: outgoing image zooms in (1 → 1.05) as it fades out.
+          // Outgoing image zooms 1 → 1.05 under the incoming one.
           secondaryImageUrl &&
-            "transition duration-200 ease-in-out group-hover:scale-105 group-hover:opacity-0"
+            "transition duration-200 ease-in-out group-hover:scale-105"
         )}
         fill
         sizes={CARD_IMAGE_SIZES}
         src={imageUrl}
       />
       {secondaryImageUrl && (
-        <Image
-          alt={title}
-          // Incoming image settles from 1.05 → 1 as it fades in.
-          className="scale-105 object-cover opacity-0 transition duration-200 ease-in-out group-hover:scale-100 group-hover:opacity-100"
-          fill
-          sizes={CARD_IMAGE_SIZES}
-          src={secondaryImageUrl}
-        />
+        <div className="card-surface absolute inset-0 opacity-0 transition-opacity duration-200 ease-in-out group-hover:opacity-100">
+          <Image
+            alt={title}
+            // Incoming image settles from 1.05 → 1 as its layer fades in.
+            className="scale-105 object-cover transition-transform duration-200 ease-in-out group-hover:scale-100"
+            fill
+            sizes={CARD_IMAGE_SIZES}
+            src={secondaryImageUrl}
+          />
+        </div>
       )}
     </>
   );

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -91,8 +91,12 @@
   --sidebar-ring: oklch(0.552 0.016 285.938);
   /* Promo bar is dark:bg-white in dark mode, so the top overscroll matches it. */
   --color-overscroll-top: oklch(1 0 0);
-  /* Card image surface stays the same light gradient in dark mode too
-   * (--card-surface-* are inherited from :root; no override). */
+  /* Card image surface in dark mode: zinc-800 -> zinc-900, per Figma node
+   * 3614:132. Note this INVERTS the light theme's direction — light goes darker
+   * at the top and lifts toward the bottom, dark does the opposite. Both stops
+   * are overridden, so nothing is inherited from :root here. */
+  --card-surface-from: #27272a;
+  --card-surface-to: #18181b;
 }
 
 @theme inline {

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -52,8 +52,8 @@
   --color-overscroll-bottom: var(--background);
   /* Card image surface: soft vertical gradient behind product/collection images
    * (transparent product shots float on this). See `card-surface` utility. */
-  --card-surface-from: #c1c6c8;
-  --card-surface-to: #e2e5e9;
+  --card-surface-from: oklch(0.823 0.006 223.471); /* #c1c6c8 */
+  --card-surface-to: oklch(0.921 0.006 255.477); /* #e2e5e9 */
 }
 
 .dark {
@@ -95,8 +95,8 @@
    * 3614:132. Note this INVERTS the light theme's direction — light goes darker
    * at the top and lifts toward the bottom, dark does the opposite. Both stops
    * are overridden, so nothing is inherited from :root here. */
-  --card-surface-from: #27272a;
-  --card-surface-to: #18181b;
+  --card-surface-from: oklch(0.274 0.006 286.033); /* zinc-800 */
+  --card-surface-to: oklch(0.21 0.006 285.885); /* zinc-900 */
 }
 
 @theme inline {


### PR DESCRIPTION
## Problem / Intent

A pale band showed across the bottom of product cards on hover in dark mode —
visible on the collections grid and in featured sections. Two separate causes,
both in `card-surface`:

1. **The crossfade bled.** Cards with a second image faded both layers in
   opposite directions. Two layers at opacity `a` and `1−a` only cover
   `a + (1−a)²` of the box, which bottoms out at **75%** — so 25% of the
   gradient behind them showed through at the midpoint.
2. **Dark mode had no gradient of its own.** Only `:root` defined
   `--card-surface-*`, so dark mode inherited the *light* gradient and cards sat
   on a pale panel. The gradient's lightest stop is at the bottom, which is
   exactly where the band appeared.

## Approach

**Crossfade.** The outgoing image no longer fades at all. The incoming one now
carries its own copy of the gradient and fades in over the top, so coverage
stays 100% throughout and both layers composite against an identical backdrop —
mathematically it can no longer bleed.

Giving the incoming layer a real backdrop matters: these are transparent PNGs,
so simply leaving the outgoing image opaque underneath would show the previous
product through the incoming one's cutout.

Timing is untouched — same `duration-200`, no added delay.

**Gradient.** Both stops now come from Figma (node `3614:132`): zinc-800 at the
top to zinc-900 at the bottom. Worth knowing that this **inverts** the light
theme's direction — light is darker at the top and lifts toward the bottom, dark
does the opposite. There's a comment on it so it doesn't read as a mistake.

## How to test

1. `pnpm dev:web`, switch to dark mode.
2. Go to `/collections/jackets` and hover a card that has a second image. Watch
   the bottom edge through the transition — no pale band at any point.
3. Check a featured-products section on the homepage, which renders the same card.
4. Sanity-check light mode is unchanged: hover a card on `/collections`, the
   crossfade should look exactly as before.
5. Card surfaces also back the PDP gallery — worth a glance there in both themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined product card hover behavior so the primary image zooms smoothly while the secondary image cross-fades more consistently.
  * Updated light/dark card surface gradients to use the correct color stops for more accurate theming.
* **Documentation**
  * Clarified OG (Open Graph) gradient color requirements to ensure consistent rendering when generating previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->