### PR TITLE
fix:carry the card surface into the PDP fullscreen viewer

### DIFF
--- a/apps/web/src/components/product/product-lightbox.tsx
+++ b/apps/web/src/components/product/product-lightbox.tsx
@@ -423,11 +423,15 @@ export function ProductLightbox({
       >
         <DialogTitle className="sr-only">Product image viewer</DialogTitle>
 
-        {/* Backdrop — fades in/out independently of the zooming image */}
+        {/* Backdrop — fades in/out independently of the zooming image.
+         * Carries the gallery's `card-surface` gradient so the surface behind a
+         * transparent product doesn't jump from gradient to flat as the FLIP
+         * lifts the image off its card. `bg-background` stays as the opaque base
+         * layer under the gradient — the utility only sets background-image. */}
         <button
           aria-label="Close"
           className={cn(
-            "absolute inset-0 bg-background transition-opacity",
+            "card-surface absolute inset-0 bg-background transition-opacity",
             active ? "opacity-100" : "opacity-0"
           )}
           onClick={requestClose}


### PR DESCRIPTION
Gallery images sit on the `card-surface` gradient; the lightbox backdrop was flat
`bg-background`. Opening an image zoomed it out of its card and swapped the surface
underneath at the same time, gradient to flat, then back on close. Worst in dark mode,
where flat `#141414` met the zinc-800/900 gradient.

Fix is one class on the backdrop (`product-lightbox.tsx:430`). `bg-background` stays as
the opaque base, since `card-surface` only sets `background-image`. The backdrop is a
sibling of the animated image, so the fade, the FLIP, the reduced-motion path and
`NavGhost` didn't need touching.

## Testing

Checked `/products/rye-leather-moto-jacket` in both themes. The canvas now runs the same
gradient as the card, and the product photo's own grey studio backdrop blends into it
with no findable image edge. Arrow nav still crossfades cleanly, close FLIP unmounts with
body scroll restored. `pnpm lint` and `pnpm check-types` pass.

Two things I did not cover. Reduced motion was not exercised in the browser, though it
only changes when the backdrop fades rather than what it paints. And I verified before
pulling 90ee3cb, so the interaction with that scroll-lock change is unobserved.

One thing to eyeball: the round controls are `bg-background/80`, and in dark mode
`--background` (oklch 0.191) sits very close to `--card-surface-to` (oklch 0.21), so they
now have less contrast behind them. `shadow-sm` plus `backdrop-blur-sm` still separates
them in my screenshots. `bg-background/90` if they read faint to you.

## PREVIEW 
<img width="2102" height="2472" alt="CleanShot 2026-07-30 at 14 29 54@2x" src="https://github.com/user-attachments/assets/11c6fa01-d821-4adc-96f1-f8b2c1df1d2c" />
<img width="2102" height="2472" alt="CleanShot 2026-07-30 at 14 29 46@2x" src="https://github.com/user-attachments/assets/8fec236e-2fbc-450c-b280-08cb8636ecd9" />
<img width="4014" height="2472" alt="CleanShot 2026-07-30 at 14 29 25@2x" src="https://github.com/user-attachments/assets/8def5b07-f160-448d-a9a5-47b7b1173fa7" />
<img width="2218" height="2472" alt="CleanShot 2026-07-30 at 14 18 20@2x" src="https://github.com/user-attachments/assets/303ea069-fd42-46cc-bbea-502d1b976c62" />
<img width="1536" height="2472" alt="CleanShot 2026-07-30 at 14 18 09@2x" src="https://github.com/user-attachments/assets/6ff7e459-2afa-4c46-ada5-c5d14b11fb43" />
<img width="4016" height="2472" alt="CleanShot 2026-07-30 at 14 17 43@2x" src="https://github.com/user-attachments/assets/e03bb9aa-3264-480c-bc9b-91e1b1505843" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the product image lightbox backdrop styling with a card-like surface while preserving its fade and opacity transitions.
  * Improved the backdrop’s visual gradient behavior for a more polished viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->