### PR TITLE
ROB-2510: agent skills for the page builder and AI assistant

### DIFF
--- a/.claude/skills/add-pagebuilder-block/SKILL.md
+++ b/.claude/skills/add-pagebuilder-block/SKILL.md
@@ -211,7 +211,7 @@ Then end-to-end:
 1. `pnpm dev`
 2. In Studio (:3333), open the home page, add the block via the insert menu, confirm it appears under the expected group, and fill in the fields.
 3. On :3000, confirm it renders.
-4. **Confirm Visual Editing click-to-edit works on it** — clicking the block in Presentation should jump to the right field. This proves the `createSanityDataAttribute` wiring, which is easy to get silently wrong and is invisible on the page otherwise.
+4. **Confirm Visual Editing click-to-edit works on it** — clicking the block in Presentation should jump to the right field. This proves the `data-sanity` attribute that `pagebuilder.tsx` puts on each block via `createBlockDataAttribute(block._key)`, which is easy to get silently wrong and is invisible on the page otherwise.
 5. Leave the field values empty and confirm it degrades gracefully rather than throwing.
 6. Discard the test content when done.
 

--- a/.claude/skills/add-pagebuilder-block/SKILL.md
+++ b/.claude/skills/add-pagebuilder-block/SKILL.md
@@ -209,7 +209,7 @@ Then end-to-end:
 ## Common Mistakes
 
 - **Editing `packages/sanity/src/sanity.types.ts` by hand.** It's generated. Run `pnpm --filter studio type`.
-- **Writing to `apps/web/src/lib/sanity/sanity.types.ts`.** Stale duplicate. The live one is in `packages/sanity`.
+- **Importing generated types from anywhere but `@workspace/sanity/types`.** That is the only copy, generated into `packages/sanity/src/sanity.types.ts`.
 - **Adding `fetch` to a section component.** Client boundary — see Part B.
 - **Adding `"use client"` to a section component.** Already inside one.
 - **Omitting the `/* groq */` comment.** Typegen won't see the fragment and the types come back wrong.

--- a/.claude/skills/add-pagebuilder-block/SKILL.md
+++ b/.claude/skills/add-pagebuilder-block/SKILL.md
@@ -17,6 +17,15 @@ The work is deterministic — every insertion point is known — but it spans bo
 
 1. `apps/studio/schemaTypes/blocks/` and `apps/web/src/components/sections/` exist. If not, this isn't a `turbo-start-shopify` project.
 2. Working tree is reasonably clean, so the user can review the diff.
+3. `apps/studio/.env` or `apps/studio/.env.local` exists and has a real `SANITY_STUDIO_PROJECT_ID`. A fresh clone ships only `.env.example`. Step 5 runs typegen, which reaches the Sanity API and cannot work without it — so check now rather than after writing five files.
+
+If the env file is missing, stop and ask the user for it. Do not invent a project ID.
+
+Typegen failures here are badly reported. `Failed to load configuration file` names no cause and has several. Unmask it before guessing:
+
+```bash
+cd apps/studio && pnpm exec tsx -e 'import("./sanity.config.ts").catch(e => console.log(e.message))'
+```
 
 ## Before you start
 

--- a/.claude/skills/add-pagebuilder-block/SKILL.md
+++ b/.claude/skills/add-pagebuilder-block/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: add-pagebuilder-block
+description: Use when adding a new block to the Sanity page builder — creates the schema, GROQ fragment, React section component and both registry entries, then regenerates types. Use when the user says "add a block", "new page builder section", "add a section to the page builder", or names a section they want built.
+---
+
+# Add a Page Builder Block
+
+## Overview
+
+Adds one block to the page builder. Two new files, six edits, one blocking codegen step.
+
+The work is deterministic — every insertion point is known — but it spans both apps and the shared `packages/sanity`, and a block that is registered in some places and not others fails in a specific, confusing way. Follow the order below; step 5 blocks step 6.
+
+## Prerequisites
+
+**STOP and check:**
+
+1. `apps/studio/schemaTypes/blocks/` and `apps/web/src/components/sections/` exist. If not, this isn't a `turbo-start-shopify` project.
+2. Working tree is reasonably clean, so the user can review the diff.
+
+## Before you start
+
+Ask all of these and **wait for the user to answer before proceeding**:
+
+1. **Block name and title?** Name is camelCase and becomes the schema `name` and the `_type` (e.g. `quoteBanner`). File names are kebab-case (`quote-banner.ts`).
+2. **Which insert-menu group?** `heroBanners` (Hero & Banners) · `content` (Content) · `cards` (Cards & Categories) · `faq` (FAQ) · `commerce` (Commerce). Groups are defined in `apps/studio/schemaTypes/definitions/pagebuilder.ts`. A block may belong to more than one; a block in none still appears under "All".
+3. **Does it need Shopify product data?** Determines whether Part B runs. Most blocks don't.
+4. **What fields?** Get specifics — names, types, which are optional. If the user is vague, propose a shape and confirm before writing.
+
+Also pick a [lucide](https://lucide.dev) icon for the Studio picker.
+
+---
+
+## Part A: Always
+
+### 1. Schema — `apps/studio/schemaTypes/blocks/<kebab-name>.ts`
+
+Follow `blocks/cta.ts` as the reference. `defineType` with `name`, `type: "object"`, `icon`, `description`, `fields`, `preview`. No `title` key — Sanity derives it from `name`.
+
+```ts
+import { QuoteIcon } from "lucide-react";
+import { defineField, defineType } from "sanity";
+
+import { buttonsField } from "@/schemaTypes/common";
+import { customRichText } from "@/schemaTypes/definitions/rich-text";
+
+export const quoteBanner = defineType({
+  name: "quoteBanner",
+  type: "object",
+  icon: QuoteIcon,
+  description: "…what an editor sees when choosing this block",
+  fields: [
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      description: "…what this field is for",
+    }),
+  ],
+  preview: {
+    select: { title: "title" },
+    prepare: ({ title }) => ({
+      title: title || "Untitled",
+      subtitle: "Quote Banner",
+      media: QuoteIcon,
+    }),
+  },
+});
+```
+
+Reuse the shared helpers rather than redefining them:
+
+| Helper | From | Used as |
+|---|---|---|
+| `buttonsField` | `@/schemaTypes/common` | a field value — drop it straight into `fields` |
+| `richTextField` | `@/schemaTypes/common` | a field value |
+| `iconField` | `@/schemaTypes/common` | a field value |
+| `imageWithAltField` | `@/schemaTypes/common` | **a function** — `imageWithAltField({ name: "image", title: "Image", description: "…" })`, all options optional |
+| `customRichText` | `@/schemaTypes/definitions/rich-text` | **a function** — `customRichText(["block"])` to restrict which members are allowed |
+
+Every field needs a `description` — it is the editor-facing help text, and the Studio conventions in `.cursor/rules/sanity-rules.mdc` require it. Always give `preview.prepare` a fallback title; blocks with no content render as "Untitled" rather than blank.
+
+### 2. Register the schema — `apps/studio/schemaTypes/blocks/index.ts`
+
+Add the import and push into `pageBuilderBlocks`. Keep the array alphabetical.
+
+### 3. Insert-menu group — `apps/studio/schemaTypes/definitions/pagebuilder.ts`
+
+Add the block `name` to the chosen group's `of` array. Skip only if the user chose no group.
+
+### 4. GROQ fragment — `packages/sanity/src/query.ts`
+
+Add a fragment beside the other per-block fragments, then include it in `pageBuilderFragment`:
+
+```ts
+const quoteBannerBlock = /* groq */ `
+  _type == "quoteBanner" => {
+    ...,
+    ${richTextFragment},
+    ${buttonsFragment},
+  }
+`;
+```
+
+The `/* groq */` comment is required — it's what the typegen parser keys on. Spread `...` first, then pull in only the fragments matching fields you actually defined. Available: `imageFragment`, `richTextFragment`, `buttonsFragment`, `customLinkFragment`.
+
+**The shared fragments hardcode their field names.** `imageFragment` opens with `image {`, `richTextFragment` with `richText[]{`, `buttonsFragment` with `buttons[]{`. Your schema field must use exactly that name or the fragment silently matches nothing and the field arrives `undefined` on the frontend — with no error anywhere.
+
+So `imageWithAltField()` with its default name works; `imageWithAltField({ name: "portrait" })` does not. Either keep the default name, or inline the projection using `imageFields` (the inner fragment, without the `image {` wrapper) under your own key.
+
+Then add `${quoteBannerBlock},` to `pageBuilderFragment`.
+
+### 5. Regenerate types — **blocking**
+
+```bash
+pnpm --filter studio type
+```
+
+This runs `sanity schema extract --enforce-required-fields && sanity typegen generate`, rewriting `packages/sanity/src/sanity.types.ts` and `apps/studio/schema.json`.
+
+**Step 6 cannot typecheck until this completes.** If it errors, the schema or the fragment is malformed — fix it here rather than pressing on.
+
+### 6. Section component — `apps/web/src/components/sections/<kebab-name>.tsx`
+
+Follow `sections/cta.tsx`. Type it off the generated types — never hand-write the prop shape:
+
+```tsx
+import type { PagebuilderType } from "@/types";
+
+export type QuoteBannerProps = PagebuilderType<"quoteBanner">;
+
+export function QuoteBanner({ title }: QuoteBannerProps) {
+  return (
+    <section className="py-12 md:py-20">
+      <div className="site-container">…</div>
+    </section>
+  );
+}
+```
+
+No `"use client"` — it's already inside the client boundary of `pagebuilder.tsx`. Use `packages/ui` primitives and the `site-container` class for consistent page width. Sanity fields are frequently nullable under `noUncheckedIndexedAccess`; guard rather than assert.
+
+### 7. Register the component — `apps/web/src/components/pagebuilder.tsx`
+
+Add the import and an entry in `BLOCK_COMPONENTS`, keyed by the schema `name`.
+
+### 8. Type union — `apps/web/src/types.ts`
+
+`PageBuilderBlockTypes` derives from the generated query result, so it usually widens on its own once step 5 has run. Verify the new `_type` is included; only edit if it isn't.
+
+---
+
+## Part B: Only if the block needs Shopify data
+
+**Skip this entirely if the user answered no to gating question 3.**
+
+Section components are under the `"use client"` boundary of `pagebuilder.tsx` and **cannot fetch Shopify**. The page fetches server-side and injects results keyed by block `_key`.
+
+Follow the `featuredProducts` precedent exactly — read these three before writing:
+
+- `apps/web/src/components/sections/featured-products.tsx`
+- the `featuredProductsByKey` prop and its doc comment in `apps/web/src/components/pagebuilder.tsx`
+- `apps/web/src/lib/shopify/featured.ts`
+
+Add a parallel prop to `PageBuilderProps`, populate it in each page that renders the page builder, and thread it through. All Shopify calls go through `storefrontQuery()` from `apps/web/src/lib/shopify/client.ts` — handle its `{ ok: false }` branch.
+
+---
+
+## Part C: Thumbnail — do not skip
+
+**The block is not finished without this.** The insert menu's grid view reads `/static/thumbnails/<schemaTypeName>.webp`. Until that file exists, the new block shows as a blank tile in the picker while every other block has a preview — so editors can't tell what it is, and it looks broken next to the rest.
+
+Nothing fails and nothing warns. It is purely visual, which is exactly why it gets missed.
+
+Hand off to the **`generate-thumbnails-agentic`** skill. Do not reimplement it — it handles placeholder uploads, screenshotting and image processing.
+
+If the user defers it, say plainly that the block will show an empty tile in the Studio until it's done.
+
+---
+
+## Verify
+
+```bash
+pnpm check-types
+pnpm lint
+```
+
+**Idempotency check.** Typegen must produce identical output on two consecutive runs. Compare the two *runs* against each other — **not** against `git`, which will always show a diff because the block is new:
+
+```bash
+cp packages/sanity/src/sanity.types.ts /tmp/types-run1.ts
+cp apps/studio/schema.json /tmp/schema-run1.json
+pnpm --filter studio type
+diff -q /tmp/types-run1.ts packages/sanity/src/sanity.types.ts
+diff -q /tmp/schema-run1.json apps/studio/schema.json
+```
+
+Both `diff`s must print nothing.
+
+Then end-to-end:
+
+1. `pnpm dev`
+2. In Studio (:3333), open the home page, add the block via the insert menu, confirm it appears under the expected group, and fill in the fields.
+3. On :3000, confirm it renders.
+4. **Confirm Visual Editing click-to-edit works on it** — clicking the block in Presentation should jump to the right field. This proves the `createSanityDataAttribute` wiring, which is easy to get silently wrong and is invisible on the page otherwise.
+5. Leave the field values empty and confirm it degrades gracefully rather than throwing.
+6. Discard the test content when done.
+
+## Common Mistakes
+
+- **Editing `packages/sanity/src/sanity.types.ts` by hand.** It's generated. Run `pnpm --filter studio type`.
+- **Writing to `apps/web/src/lib/sanity/sanity.types.ts`.** Stale duplicate. The live one is in `packages/sanity`.
+- **Adding `fetch` to a section component.** Client boundary — see Part B.
+- **Adding `"use client"` to a section component.** Already inside one.
+- **Omitting the `/* groq */` comment.** Typegen won't see the fragment and the types come back wrong.
+- **Writing step 6 before running step 5.** The types don't exist yet; you'll be guessing at the prop shape.
+- **Creating a barrel file** for the new section. Import directly.
+- **Skipping field `description`s.** They're the editor's only guidance in the Studio.
+
+## Red Flags — STOP If You Notice These
+
+- **The block renders `UnknownBlockError` instead of your component.** The `_type` is in the GROQ fragment but missing from `BLOCK_COMPONENTS`, or the keys don't match. Both registries must agree, and the key is the schema `name`, not the file name.
+- **The block doesn't appear in the Studio insert menu at all.** It's missing from `pageBuilderBlocks` in `blocks/index.ts`.
+- **It appears in the menu but the fields come back `undefined` on the frontend.** The GROQ fragment is missing from `pageBuilderFragment`, so the data is never queried.
+- **`pnpm --filter studio type` produces a diff on a second consecutive run.** Something is non-deterministic — stop and investigate rather than committing.
+- **You're about to define a button, image or rich-text field from scratch.** Use `buttonsField`, `imageWithAltField` or `customRichText` — hand-rolled versions won't match the existing GROQ fragments and will silently return the wrong shape.
+- **You renamed an image, richText or buttons field.** The shared fragments hardcode those names — the field will come back `undefined` with no error. See step 4.
+- **You're about to report the block as done without a thumbnail.** It isn't. See Part C.

--- a/.claude/skills/enable-ai-assistant/SKILL.md
+++ b/.claude/skills/enable-ai-assistant/SKILL.md
@@ -247,11 +247,18 @@ pnpm --filter web test
 
 ### `SchemaExtractionError: Failed to load configuration file`
 
-**This message masks its cause and has at least three.** Do not assume the first one. Bisect: stash the entire port and re-run `pnpm --filter studio type` on clean `HEAD`. If it still fails, the cause is pre-existing and nothing to do with this skill.
+**This message names no cause and has more than one.** Do not guess — unmask it first:
 
-1. **`@sanity/agent-context` not installed** — the config imports `agentContextPlugin` and throws on load.
-2. **A transitive import that will not resolve under CJS.** Seen in the wild: `apps/studio/components/icon-preview.tsx` imports `lucide-react/dynamic`, and lucide-react 0.562.0 ships `dynamic.mjs` with no `exports` field, so Node's legacy CJS resolver only tries `.js`/`.json`/`.node`. Vite resolves it fine, so dev and build never surface it. Fixing it needs the `.mjs` specifier **and** a `declare module` shim, because `.mjs` alone breaks `tsc` with `TS7016: Could not find a declaration file`.
-3. **Missing env files.** With the above cleared, extraction next fails on `SANITY_STUDIO_PRESENTATION_URL must be set in production environment`, then `CorsOriginError` once a placeholder project ID is supplied — schema extraction contacts the Sanity API to validate the project. Both `apps/studio` and `apps/web` need a real env file before typegen will run. A fresh clone has only `.env.example`.
+```bash
+cd apps/studio && pnpm exec tsx -e 'import("./sanity.config.ts").catch(e => console.log(e.message))'
+```
+
+1. **`@sanity/agent-context` not installed** — the config imports `agentContextPlugin` and throws on load. This is the cause this skill actually introduces, and installing the dep before typegen is why step 3b orders it that way.
+2. **Missing env file** — a fresh clone ships only `.env.example`. Extraction reaches the Sanity API to validate the project, so it needs a real `SANITY_STUDIO_PROJECT_ID`; the failure reads `Configuration must contain projectId`, and a placeholder ID gives `CorsOriginError`. Both `apps/studio` and `apps/web` need a real env file. Either `.env` or `.env.local` works.
+
+If unmasking points at neither, bisect: stash the entire port and re-run `pnpm --filter studio type` on clean `HEAD`. If it still fails, the cause is pre-existing and has nothing to do with this skill.
+
+**Do not blame module resolution without evidence.** `require.resolve("lucide-react/dynamic")` does fail — lucide-react 0.562.0 ships no `exports` map — and that looks like a convincing cause. It is not one: the Sanity CLI does not resolve the config through CJS `require`, and typegen passes without any `.mjs` specifier on Node 24 and Node 26. We chased this once and shipped a fix for it before finding the env cause underneath.
 
 Do not read `roboto-shopify.sanity.studio` in the CLI output as proof the Studio is deployed. That is `getStudioHost()`'s fallback for an empty project ID.
 

--- a/.claude/skills/enable-ai-assistant/SKILL.md
+++ b/.claude/skills/enable-ai-assistant/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: enable-ai-assistant
+description: Use when adding the turbo-start-aisle AI shopping assistant to a turbo-start-shopify project — vendors packages/ai-commerce, wires the chat route and widget, adds the Sanity Agent Context schema, and guides the Sanity and AI Gateway setup. Use when the user says "add the AI assistant", "add the shopping assistant", "add aisle", or "add the chat widget".
+---
+
+# Enable the AI Shopping Assistant
+
+## Overview
+
+Ports the AI shopping assistant from [`robotostudio/turbo-start-aisle`](https://github.com/robotostudio/turbo-start-aisle) into a `turbo-start-shopify` project: a floating chat widget with page-context awareness, AI-driven collection filters, and inline product cards that add to the real Shopify cart.
+
+The assistant reaches Sanity through **MCP (Agent Context)**, which is schema-aware at runtime. It does *not* query product data through `packages/sanity/src/query.ts`, so it does not drift against local GROQ fragments.
+
+**Fallback behaviour is the point.** `AI_GATEWAY_API_KEY` and `SANITY_CONTEXT_MCP_URL` both default to an empty string, and `/api/chat` returns 503 until both are set. A project that ports the assistant but never finishes setup must still install, typecheck, build and serve normally. Never make these variables required.
+
+## Source of truth
+
+Aisle was reset to `turbo-start-shopify@9eb2555` in commit `f90fc3c`, then the AI layer was applied on top. **The delta is exactly `aisle@f90fc3c..e7af3e5`.** Treat that range as definitive — do not invent an integration, and do not copy from an older aisle commit.
+
+Fetch files from `https://raw.githubusercontent.com/robotostudio/turbo-start-aisle/main/<path>`.
+
+## Prerequisites
+
+**STOP and check these before proceeding:**
+
+1. **This is a `turbo-start-shopify` project.** `packages/sanity`, `packages/ui`, `packages/env` and `apps/studio` must exist. If not, stop.
+2. **Working tree is clean.** `git status --short` must be empty. This skill edits shared files; the user needs a clean diff to review. If dirty, **STOP** and ask them to commit or stash.
+3. **On a branch, not `main`.** If on the default branch, create one first.
+
+## Before you start
+
+Ask all of these and **wait for the user to answer before proceeding**:
+
+1. **Do you have a Vercel AI Gateway account?** Free credits on signup at https://vercel.com/dashboard/ai-gateway. Needed for local dev; Vercel deployments authenticate via OIDC.
+2. **Is your Sanity Studio deployed?** An Agent Context document cannot be created until it is. If not, Part D step 1 handles it.
+3. **Which model and failover chain?** Default: Gemini 3 Flash → Claude Haiku 4.5 → GPT-5 Mini.
+4. **Gate the widget behind `NEXT_PUBLIC_ENABLE_AI_ASSISTANT`?** Aisle itself does not — it ships the widget always and degrades to a 503. Recommend the flag here, so a user who ports but never configures doesn't get a dead chat bubble. Their call.
+5. **How far has this project diverged from `turbo-start-shopify@9eb2555`?** Run `git log --oneline 9eb2555..HEAD -- apps/web/src/lib/markdown apps/web/src/lib/seo.ts apps/web/src/app/layout.tsx 2>/dev/null | head`. If those files have local changes, warn that Part B needs manual reconciliation rather than wholesale replacement.
+
+## Process
+
+```
+Part A  →  new files          (pure additions, low risk)
+Part B  →  edits to existing  (the risky half — extend, never replace)
+Part C  →  install + typegen
+Part D  →  guided manual setup (stop at each gate)
+Part E  →  verify
+```
+
+---
+
+## Part A: New files
+
+Pure additions. Nothing here can break existing behaviour.
+
+**1. Vendor the package.** Copy `packages/ai-commerce/` from aisle in full:
+
+```
+packages/ai-commerce/
+  package.json
+  tsconfig.json
+  src/
+    index.ts          system-prompt.ts    types.ts
+    context/  lib/  mcp/  tools/  ui/
+```
+
+`src/ui/` is 7 components: `chat-panel`, `chat-widget`, `empty-state`, `message-input`, `message-list`, `product`, `text-part`.
+
+**2. Record the source SHA.** Create `packages/ai-commerce/README.md` stating which aisle commit this was ported from and the date. Without it there is no way to ever diff or update the vendored copy. Get the SHA with:
+
+```bash
+curl -s https://api.github.com/repos/robotostudio/turbo-start-aisle/commits/main | grep '"sha"' | head -1
+```
+
+**3. Add the `textarea` primitive.** It is the one shadcn component `packages/ui` lacks and `src/ui/message-input.tsx` needs:
+
+```bash
+pnpm dlx shadcn@latest add textarea -c packages/ui
+```
+
+Use the CLI. Do not hand-write it.
+
+**4. New app files** — copy from aisle:
+
+| Path | Purpose |
+|---|---|
+| `apps/web/src/app/api/chat/route.ts` | AI Gateway handler, MCP client, failover chain |
+| `apps/web/src/components/page-context-tracker.tsx` | Keeps the chat aware of the current route |
+| `apps/web/src/components/ai-cart-bridge.tsx` | Bridges chat "add to cart" into `CartProvider` |
+| `apps/studio/schemaTypes/documents/ai-assistant-settings.ts` | Agent Context settings document |
+| `apps/studio/scripts/seed-ai-assistant.ts` | Creates the Agent Context document programmatically — saves the user doing it by hand in Part D |
+
+---
+
+## Part B: Edits to existing files
+
+**This is the risky half.** Every file below already exists and is in use. **Extend it; never replace it wholesale.** Read the local file first, read aisle's version second, and apply only the delta.
+
+**1. `apps/web/src/app/layout.tsx`** — mount the three components **inside `<Providers>`**, after `{modal}`:
+
+```tsx
+<PageContextTracker />
+<AiCartBridge />
+<ChatWidget currencyCode={env.NEXT_PUBLIC_STORE_CURRENCY} />
+```
+
+Ordering is not cosmetic — `PageContextTracker` needs `QueryClientProvider`, `AiCartBridge` needs `CartProvider`, and `ChatWidget` queries Sanity through react-query. All three are supplied by `Providers`. Mounting them outside it throws at runtime.
+
+Also offset the existing `<Toaster>` so it doesn't sit under the fixed chat launcher — aisle uses `bottom: 5.5rem, right: 1rem`.
+
+If the user chose the feature flag, wrap all three in the `env.NEXT_PUBLIC_ENABLE_AI_ASSISTANT` check.
+
+**2. `apps/web/src/lib/markdown/{documents,page-builder,portable-text,shared}.ts`** — extended for assistant context capture.
+
+**These have tests in `apps/web/src/lib/markdown/__tests__/`.** This is the highest-risk edit in the port. They are also shared with the `llms.txt` and `/api/markdown` surfaces that already ship in this repo. Run `pnpm --filter web test` immediately after editing, before moving on.
+
+**3. `apps/web/src/app/api/markdown/route.ts` and `apps/web/src/app/llms.txt/route.ts`** — assistant-aware surfaces. Small deltas.
+
+**4. `apps/web/src/lib/seo.ts`** — assistant metadata.
+
+**5. `packages/sanity/src/query.ts`** — add the `aiAssistantSettings` fetch (~8 lines). This is the *only* GROQ the assistant needs. Do not add product fragments for it; product data comes through MCP.
+
+**6. Studio wiring:**
+- `apps/studio/schemaTypes/documents/index.ts` — register `aiAssistantSettings`
+- `apps/studio/structure.ts` — add the Agent Context entry
+- `apps/studio/sanity.config.ts` — plugin registration
+
+**7. `packages/env/src/server.ts`** — both **optional**, empty-string defaults:
+
+```ts
+AI_GATEWAY_API_KEY: z.string().default(""),
+SANITY_CONTEXT_MCP_URL: z.string().default(""),
+```
+
+If the user chose the flag, add `NEXT_PUBLIC_ENABLE_AI_ASSISTANT` to `packages/env/src/client.ts` — remembering the `experimental__runtimeEnv` entry, which client vars require and server vars don't.
+
+**8. `turbo.json`** — add the new variables to `globalEnv`.
+
+**9. `apps/web/.env.example`** — document them, including that the gateway key is local-dev-only because Vercel uses OIDC.
+
+**10. `packages/ui/src/styles/globals.css`** — one line from aisle.
+
+**11. `package.json` files**
+
+`apps/web` gains `@workspace/ai-commerce`. `@tanstack/react-query` is already present and already wired — **do not add a second `QueryClientProvider`.**
+
+`apps/studio` gains the `@sanity/agent-context` dependency **and four scripts that do not exist in this repo yet** — Part D depends on `schema:deploy`, so this is not optional:
+
+```jsonc
+"clean": "rm -rf dist schema.json",
+"predeploy": "pnpm run clean",
+"schema:deploy": "pnpm run clean && sanity schema extract --enforce-required-fields && sanity schema deploy",
+"seed:ai-assistant": "sanity exec scripts/seed-ai-assistant.ts --with-user-token"
+```
+
+Note `sanity schema deploy` is a different command from `sanity deploy` — the first publishes the schema so Agent Context can read it, the second publishes the Studio. Both are needed.
+
+---
+
+## Part C: Install and generate
+
+```bash
+pnpm install
+pnpm --filter studio type    # regenerates packages/sanity/src/sanity.types.ts
+pnpm check-types
+pnpm lint
+pnpm --filter web test
+```
+
+All five must pass before Part D. If typegen reports schema errors, the `ai-assistant-settings` document is registered wrong — fix that before continuing.
+
+---
+
+## Part D: Guided manual setup
+
+These steps need a human. **Stop at each gate and wait — do not guess values.**
+
+**1. Deploy the Studio**
+
+```bash
+pnpm --filter studio run schema:deploy
+pnpm --filter studio run deploy
+```
+
+Needs a Sanity account with `sanity.project/deployStudio` permission. If this fails with a login error, have the user run `pnpm --filter studio exec sanity logout` then `login`.
+
+**2. Create the Agent Context document**
+
+Fastest path — the seed script added in Part B:
+
+```bash
+pnpm --filter studio seed:ai-assistant
+```
+
+Or by hand, in the deployed Studio (`https://<hostname>.sanity.studio`):
+1. **Agent Context → + Create new**
+2. Enter a name, a slug (e.g. `shop-assistant`), and instructions for the assistant
+3. **Publish** — an unpublished document will not resolve
+
+Either way, confirm with the user what instructions the assistant should carry. They shape its tone and what it will and won't answer, and are worth getting right rather than defaulting.
+
+**3. Copy the MCP URL**
+
+```
+https://api.sanity.io/v2026-04-30/agent-context/<projectId>/<dataset>/<slug>
+```
+
+**4. Get an AI Gateway key** from https://vercel.com/dashboard/ai-gateway.
+
+**5. Write both into `apps/web/.env.local`**
+
+```bash
+SANITY_CONTEXT_MCP_URL=https://api.sanity.io/v2026-04-30/agent-context/<projectId>/<dataset>/<slug>
+AI_GATEWAY_API_KEY=<key>
+```
+
+**`.env.local`, not `.env`.** Next.js precedence means `.env` will be shadowed and the user will get a confusing 503. Confirm `.env.local` is gitignored.
+
+---
+
+## Part E: Verify
+
+Run these in order. Step 2 is the one that matters most.
+
+1. `pnpm install && pnpm check-types && pnpm lint && pnpm --filter web test` — all clean.
+2. **Negative test — do this before the happy path.** With no AI env vars set (and the flag off, if used): `pnpm build` succeeds and the site serves with no chat bubble. A user who ignores the assistant must not end up with a broken project. If this fails, the env vars were made required — go back to Part B step 7.
+3. `pnpm dev` → open http://localhost:3000, click the chat bubble, ask *"show me products under $50"*. Expect real products from the Sanity dataset.
+4. Ask it to filter a collection. Confirm it actually drives `apps/web/src/components/collection/filter-panel.tsx`.
+5. Add to cart from an inline product card. Confirm the line reaches the real Shopify cart, not a local mock.
+6. Visit `/llms.txt` and a `/api/markdown` URL — both were modified in Part B and must still render.
+7. Check https://vercel.com/dashboard/ai-gateway → Logs for the request. To test failover, set a bogus primary model and confirm it falls through.
+8. Confirm `packages/ai-commerce/README.md` records the aisle SHA.
+
+---
+
+## Common Mistakes
+
+- **Mounting the AI components outside `<Providers>`.** Throws at runtime — they need `QueryClientProvider` and `CartProvider`.
+- **Adding a second `QueryClientProvider`.** `apps/web/src/components/providers.tsx` already has one.
+- **Making the env vars required.** Breaks the build for everyone who hasn't set up the assistant. They default to `""`; the route returns 503.
+- **Writing to `.env` instead of `.env.local`.** Next.js precedence silently shadows it.
+- **Replacing the markdown lib files wholesale.** They are shared with `llms.txt` and `/api/markdown`. Extend only, then run the tests.
+- **Hand-editing `packages/sanity/src/sanity.types.ts`.** Generated — run `pnpm --filter studio type`.
+- **Hand-writing `textarea.tsx`.** Use the shadcn CLI.
+- **Adding GROQ fragments for product data.** Products come through MCP. `query.ts` changes only for the settings document.
+- **Copying `SHOPIFY_API_VERSION` from aisle.** Aisle defaults to `2026-04`, this repo to `2025-01`. Not part of the AI layer — leave it alone.
+- **Forgetting to publish the Agent Context document.** A draft will not resolve, and the failure looks like a bad MCP URL.
+
+## Red Flags — STOP If You Notice These
+
+- **You are about to commit `.env.local` or paste a key into source.** Never. Both belong in `.env.local` only.
+- **You are about to echo a raw error from `/api/chat` to the client.** The route deliberately does not — raw errors can leak `SANITY_API_READ_TOKEN` or `AI_GATEWAY_API_KEY`.
+- **You are removing the 4MB request cap or the 8-step tool ceiling.** Both exist to bound spend on an endpoint that costs real money per call. Keep them.
+- **The user is about to deploy this publicly.** `/api/chat` is **unauthenticated and consumes paid AI Gateway and MCP resources** — aisle's own source carries this warning. Tell the user plainly, before they deploy, that they need auth and rate limiting first. Do not bury it in a summary.
+- **`pnpm --filter web test` fails after Part B.** You broke the markdown lib. Fix it before continuing; do not proceed and hope.
+- **The project has diverged far from `9eb2555`.** The Part B files have local changes. Reconcile by hand and tell the user which files needed judgement calls.

--- a/.claude/skills/enable-ai-assistant/SKILL.md
+++ b/.claude/skills/enable-ai-assistant/SKILL.md
@@ -46,6 +46,11 @@ Before copying any shared file wholesale, read the diff and classify it. If a hu
 1. **This is a `turbo-start-shopify` project.** `packages/sanity`, `packages/ui`, `packages/env` and `apps/studio` must exist. If not, stop.
 2. **Working tree is clean.** `git status --short` must be empty. This skill edits shared files; the user needs a clean diff to review. If dirty, **STOP** and ask them to commit or stash.
 3. **On a branch, not `main`.** If on the default branch, create one first.
+4. **A working Sanity project already exists.** `apps/studio/.env` or `.env.local` must have a real `SANITY_STUDIO_PROJECT_ID`, and `pnpm --filter studio type` must pass *before* you change anything.
+
+This skill adds the assistant to a project that already runs. It does not set turbo-start-shopify up from scratch. Almost every step depends on a live Sanity project: typegen validates the project ID against the Sanity API, Part D deploys the Studio, and the Agent Context document can only be created inside a deployed Studio.
+
+If there is no project yet, stop and send the user through the template's own onboarding first — create a Sanity project, fill in both env files, import the seed dataset. Then come back. Running this skill first means failing at typegen with five new files already written.
 
 ## Before you start
 
@@ -325,12 +330,20 @@ https://api.sanity.io/v2026-04-30/agent-context/<projectId>/<dataset>/<slug>
 
 **4. Get an AI Gateway key** from https://vercel.com/dashboard/ai-gateway.
 
-**5. Write both into the web app's env file**
+**5. Write these into the web app's env file**
 
 ```bash
 SANITY_CONTEXT_MCP_URL=https://api.sanity.io/v2026-04-30/agent-context/<projectId>/<dataset>/<slug>
 AI_GATEWAY_API_KEY=<key>
 ```
+
+**If the user chose the feature flag in question 4, add it here too:**
+
+```bash
+NEXT_PUBLIC_ENABLE_AI_ASSISTANT=true
+```
+
+It defaults to `false`, so skipping this line leaves the widget unmounted no matter how correct everything else is — no bubble, no error, nothing to debug. Setting the keys is not enough on its own.
 
 **Use whichever file the project already has, and never create both.** `CLAUDE.md` documents `apps/web/.env` as this repo's convention, and `.env` works fine on its own. The hazard is precedence: Next.js ranks `.env.local` above `.env`, so if values go in `.env` and someone later adds a `.env.local`, the assistant silently 503s with no obvious cause.
 
@@ -349,6 +362,8 @@ Run these in order. Step 2 is the one that matters most.
 1. `pnpm install && pnpm check-types && pnpm lint && pnpm --filter web test` — all clean.
 2. **Negative test — do this before the happy path.** With no AI env vars set (and the flag off, if used): `pnpm build` succeeds and the site serves with no chat bubble. A user who ignores the assistant must not end up with a broken project. If this fails, the env vars were made required — go back to Part B step 7.
 3. `pnpm dev` → open http://localhost:3000, click the chat bubble, ask *"show me products under $50"*. Expect real products from the Sanity dataset.
+
+   **No bubble at all?** If the flag is in use, check `NEXT_PUBLIC_ENABLE_AI_ASSISTANT=true` is actually in the env file — it defaults to `false`, and an unmounted widget looks identical to a broken port. Also confirm the `experimental__runtimeEnv` entry exists in `packages/env/src/client.ts`; without it the value reads `undefined` at runtime however you set it. Restart `pnpm dev` after either change — `NEXT_PUBLIC_` vars are inlined at build time.
 4. Ask it to filter a collection. Confirm it actually drives `apps/web/src/components/collection/filter-panel.tsx`.
 5. Add to cart from an inline product card. Confirm the line reaches the real Shopify cart, not a local mock.
 6. Visit `/llms.txt` and a `/api/markdown` URL — both were modified in Part B and must still render.
@@ -372,6 +387,8 @@ Run these in order. Step 2 is the one that matters most.
 - **Adding GROQ fragments for product data.** Products come through MCP. `query.ts` changes only for the settings document.
 - **Copying `SHOPIFY_API_VERSION` from aisle.** Aisle defaults to `2026-04`, this repo to `2025-01`. Not part of the AI layer — leave it alone.
 - **Forgetting to publish the Agent Context document.** A draft will not resolve, and the failure looks like a bad MCP URL.
+- **Adding the feature flag but never setting it to `true`.** It defaults to `false`, so every other step can be correct and the widget still never mounts. Part D step 5 sets it.
+- **Running this skill on a project with no Sanity project yet.** Typegen validates the project ID against the Sanity API, so it fails after files are already written. Check Prerequisite 4 first.
 
 ## Red Flags — STOP If You Notice These
 

--- a/.claude/skills/enable-ai-assistant/SKILL.md
+++ b/.claude/skills/enable-ai-assistant/SKILL.md
@@ -15,9 +15,29 @@ The assistant reaches Sanity through **MCP (Agent Context)**, which is schema-aw
 
 ## Source of truth
 
-Aisle was reset to `turbo-start-shopify@9eb2555` in commit `f90fc3c`, then the AI layer was applied on top. **The delta is exactly `aisle@f90fc3c..e7af3e5`.** Treat that range as definitive — do not invent an integration, and do not copy from an older aisle commit.
+Aisle periodically resets its base to a `turbo-start-shopify` commit, then re-applies the AI layer on top. **Never hardcode that commit** — it goes stale within weeks. Derive it every run.
 
-Fetch files from `https://raw.githubusercontent.com/robotostudio/turbo-start-aisle/main/<path>`.
+Clone aisle and find its sync point:
+
+```bash
+git clone --depth 50 https://github.com/robotostudio/turbo-start-aisle.git /tmp/aisle-src
+git -C /tmp/aisle-src log --oneline -15   # look for "sync upstream <sha>" or "Reset foundation to <sha>"
+git -C /tmp/aisle-src rev-parse HEAD      # record this — it goes in the vendored README
+```
+
+Then diff aisle against the local project **file by file** and apply only what is genuinely the AI layer. A full clone beats fetching raw files one at a time.
+
+### Not every difference is the AI layer
+
+This is the trap. The diff between aisle and this project contains three kinds of change, and only the first should be ported:
+
+| Kind | Example | Action |
+|---|---|---|
+| **AI layer** | `structure.ts` AI Assistant list, `server.ts` env vars | port |
+| **Aisle's branding** | `seo.ts` title/keywords/Twitter handle, `llms.txt` `SITE_TITLE` | **never port — it overwrites the user's site identity** |
+| **Unrelated upstream work** | `client.ts` URL validation, `SHOPIFY_API_VERSION` bumps | don't port here; mention it to the user as a separate cherry-pick |
+
+Before copying any shared file wholesale, read the diff and classify it. If a hunk does not mention AI, chat, agent, or the assistant, it is not this skill's business.
 
 ## Prerequisites
 
@@ -35,7 +55,13 @@ Ask all of these and **wait for the user to answer before proceeding**:
 2. **Is your Sanity Studio deployed?** An Agent Context document cannot be created until it is. If not, Part D step 1 handles it.
 3. **Which model and failover chain?** Default: Gemini 3 Flash → Claude Haiku 4.5 → GPT-5 Mini.
 4. **Gate the widget behind `NEXT_PUBLIC_ENABLE_AI_ASSISTANT`?** Aisle itself does not — it ships the widget always and degrades to a 503. Recommend the flag here, so a user who ports but never configures doesn't get a dead chat bubble. Their call.
-5. **How far has this project diverged from `turbo-start-shopify@9eb2555`?** Run `git log --oneline 9eb2555..HEAD -- apps/web/src/lib/markdown apps/web/src/lib/seo.ts apps/web/src/app/layout.tsx 2>/dev/null | head`. If those files have local changes, warn that Part B needs manual reconciliation rather than wholesale replacement.
+5. **How far has this project diverged from aisle's sync point?** With `<sync-sha>` from the step above, run:
+
+   ```bash
+   git log --oneline <sync-sha>..HEAD -- apps/web/src/app/layout.tsx apps/studio/structure.ts packages/sanity/src/query.ts
+   ```
+
+   Empty means the shared files can be taken wholesale. Any output means reconcile those files by hand instead.
 
 ## Process
 
@@ -75,10 +101,31 @@ curl -s https://api.github.com/repos/robotostudio/turbo-start-aisle/commits/main
 **3. Add the `textarea` primitive.** It is the one shadcn component `packages/ui` lacks and `src/ui/message-input.tsx` needs:
 
 ```bash
-pnpm dlx shadcn@latest add textarea -c packages/ui
+pnpm dlx shadcn@latest add textarea -c packages/ui --yes
 ```
 
-Use the CLI. Do not hand-write it.
+Use the CLI. Do not hand-write it. (Check first — a later `turbo-start-shopify` may already ship it.)
+
+**3b. Install dependencies now — before any other edit.**
+
+Nothing below will typecheck or even load until these exist. Doing this late is the single most common way to get stuck.
+
+```bash
+pnpm --filter studio add "@sanity/agent-context@^0.1.0"
+pnpm --filter web add "ai@^6.0.0" "@ai-sdk/gateway@^3.0.112" "@ai-sdk/react@^3.0.0"
+```
+
+Why each matters:
+- `@sanity/agent-context` — `sanity.config.ts` imports `agentContextPlugin`. Without it the Studio config throws, **`sanity schema extract` fails, and typegen dies with a misleading "Failed to load configuration file"**.
+- `ai`, `@ai-sdk/*` — `apps/web/src/app/api/chat/route.ts` imports them directly. They are dependencies of `packages/ai-commerce`, and pnpm's strict `node_modules` will **not** hoist them to `apps/web`. Symptom: `Cannot find module 'ai'`.
+
+Also add the workspace link in `apps/web/package.json`:
+
+```jsonc
+"@workspace/ai-commerce": "workspace:*"
+```
+
+Then `pnpm install`.
 
 **4. New app files** — copy from aisle:
 
@@ -110,41 +157,52 @@ Also offset the existing `<Toaster>` so it doesn't sit under the fixed chat laun
 
 If the user chose the feature flag, wrap all three in the `env.NEXT_PUBLIC_ENABLE_AI_ASSISTANT` check.
 
-**2. `apps/web/src/lib/markdown/{documents,page-builder,portable-text,shared}.ts`** — extended for assistant context capture.
+**2. `packages/sanity/src/query.ts`** — add the `aiAssistantSettings` fetch (~8 lines). This is the *only* GROQ the assistant needs. Do not add product fragments for it; product data comes through MCP.
 
-**These have tests in `apps/web/src/lib/markdown/__tests__/`.** This is the highest-risk edit in the port. They are also shared with the `llms.txt` and `/api/markdown` surfaces that already ship in this repo. Run `pnpm --filter web test` immediately after editing, before moving on.
-
-**3. `apps/web/src/app/api/markdown/route.ts` and `apps/web/src/app/llms.txt/route.ts`** — assistant-aware surfaces. Small deltas.
-
-**4. `apps/web/src/lib/seo.ts`** — assistant metadata.
-
-**5. `packages/sanity/src/query.ts`** — add the `aiAssistantSettings` fetch (~8 lines). This is the *only* GROQ the assistant needs. Do not add product fragments for it; product data comes through MCP.
-
-**6. Studio wiring:**
+**3. Studio wiring:**
 - `apps/studio/schemaTypes/documents/index.ts` — register `aiAssistantSettings`
-- `apps/studio/structure.ts` — add the Agent Context entry
-- `apps/studio/sanity.config.ts` — plugin registration
+- `apps/studio/structure.ts` — add the AI Assistant list (`aiAssistantSettings` singleton + `sanity.agentContext` list)
+- `apps/studio/sanity.config.ts` — `agentContextPlugin()` + add `aiAssistantSettings` to the singleton list
 
-**7. `packages/env/src/server.ts`** — both **optional**, empty-string defaults:
+**4. `packages/ui/src/styles/globals.css`** — add the Tailwind source glob for the vendored package:
+
+```css
+@source "../../../ai-commerce/**/*.{ts,tsx}";
+```
+
+Without it Tailwind never scans `ai-commerce`, and **the entire chat UI renders unstyled** — no error, no warning, just a broken-looking widget.
+
+### Files that look like they need editing but do not
+
+Verified by diffing a synced aisle against this project. Check each before assuming:
+
+| File | Reality |
+|---|---|
+| `apps/web/src/lib/markdown/*.ts` | **Zero delta.** These came *from* turbo-start-shopify; once aisle syncs upstream they are identical. Do not touch them, and do not budget risk for them |
+| `apps/web/src/app/api/markdown/route.ts` | Zero delta, same reason |
+| `apps/web/src/lib/seo.ts` | Delta is **aisle's branding** — title, description, `@akintola4`, aisle keywords. **Porting it overwrites the user's site identity.** Skip |
+| `apps/web/src/app/llms.txt/route.ts` | Delta is one line: `SITE_TITLE`. Branding. Skip |
+| `packages/env/src/client.ts` | Delta is unrelated upstream work (API-version regex, Studio-URL trailing-slash strip). Not the AI layer — mention it as a separate cherry-pick. Only touch this file if the user chose the feature flag |
+| `packages/env/src/server.ts` → `SHOPIFY_API_VERSION` | Aisle bumps it. Not the AI layer. **Leave the local value alone** |
+
+If a diff in this table is non-zero in your run, re-read it before acting — aisle may have genuinely changed something. The rule is classify-then-port, not copy-then-hope.
+
+**5. `packages/env/src/server.ts`** — add these two, and **only** these two. Both **optional**, empty-string defaults:
 
 ```ts
 AI_GATEWAY_API_KEY: z.string().default(""),
 SANITY_CONTEXT_MCP_URL: z.string().default(""),
 ```
 
+Optional is load-bearing: `/api/chat` returns 503 until both are set, so an unconfigured project still installs, typechecks and builds. Making them required breaks the build for everyone who ports but doesn't configure.
+
 If the user chose the flag, add `NEXT_PUBLIC_ENABLE_AI_ASSISTANT` to `packages/env/src/client.ts` — remembering the `experimental__runtimeEnv` entry, which client vars require and server vars don't.
 
-**8. `turbo.json`** — add the new variables to `globalEnv`.
+**6. `turbo.json`** — add both variables to `globalEnv`.
 
-**9. `apps/web/.env.example`** — document them, including that the gateway key is local-dev-only because Vercel uses OIDC.
+**7. `apps/web/.env.example`** — document them, including that the gateway key is local-dev-only because Vercel uses OIDC.
 
-**10. `packages/ui/src/styles/globals.css`** — one line from aisle.
-
-**11. `package.json` files**
-
-`apps/web` gains `@workspace/ai-commerce`. `@tanstack/react-query` is already present and already wired — **do not add a second `QueryClientProvider`.**
-
-`apps/studio` gains the `@sanity/agent-context` dependency **and four scripts that do not exist in this repo yet** — Part D depends on `schema:deploy`, so this is not optional:
+**8. `apps/studio/package.json` scripts.** Four scripts that do not exist in this repo — Part D depends on `schema:deploy`, so this is not optional:
 
 ```jsonc
 "clean": "rm -rf dist schema.json",
@@ -157,17 +215,39 @@ Note `sanity schema deploy` is a different command from `sanity deploy` — the 
 
 ---
 
-## Part C: Install and generate
+## Part C: Generate and check
+
+Dependencies were installed in Part A step 3b. If you skipped that, go back — the first two commands here will fail.
 
 ```bash
-pnpm install
 pnpm --filter studio type    # regenerates packages/sanity/src/sanity.types.ts
 pnpm check-types
 pnpm lint
 pnpm --filter web test
 ```
 
-All five must pass before Part D. If typegen reports schema errors, the `ai-assistant-settings` document is registered wrong — fix that before continuing.
+**Two failures seen in a real run, both with misleading messages:**
+
+| Symptom | Real cause |
+|---|---|
+| `SchemaExtractionError: Failed to load configuration file .../sanity.config.ts` | `@sanity/agent-context` not installed. The config imports `agentContextPlugin` and throws on load. Nothing in the message says so |
+| `Cannot find module 'ai'` in `api/chat/route.ts` | `ai` / `@ai-sdk/*` are deps of `packages/ai-commerce`, not `apps/web`. pnpm won't hoist them |
+
+`ai-commerce` will also fail `check-types` with *"`@workspace/sanity/types` has no exported member `QueryAiAssistantSettingsResult`"* until typegen has run. That one is ordering, not a missing dep — run typegen first and it resolves.
+
+Expected clean state: `check-types` passes, `lint` passes with a handful of warnings, tests pass (112 at time of writing).
+
+All four must pass before Part D.
+
+**Then the test that matters most — run it before the happy path:**
+
+```bash
+pnpm build     # with NO AI env vars set
+```
+
+It must succeed, and the site must serve normally. A user who ports the assistant and never configures it must not end up with a broken project. If this fails, the env vars were made required — go back to Part B step 5.
+
+Note the widget still *renders* when unconfigured; it just 503s on use. That is aisle's own behaviour and why the feature flag in gating question 4 is worth recommending.
 
 ---
 
@@ -239,7 +319,10 @@ Run these in order. Step 2 is the one that matters most.
 - **Adding a second `QueryClientProvider`.** `apps/web/src/components/providers.tsx` already has one.
 - **Making the env vars required.** Breaks the build for everyone who hasn't set up the assistant. They default to `""`; the route returns 503.
 - **Writing to `.env` instead of `.env.local`.** Next.js precedence silently shadows it.
-- **Replacing the markdown lib files wholesale.** They are shared with `llms.txt` and `/api/markdown`. Extend only, then run the tests.
+- **Editing the markdown lib at all.** Its delta against a synced aisle is zero. Leave it alone.
+- **Installing dependencies late.** `@sanity/agent-context` and `ai`/`@ai-sdk/*` must land before typegen, or you get two misleading errors. See Part A step 3b.
+- **Skipping the `globals.css` `@source` line.** Tailwind never scans the vendored package and the chat UI renders unstyled, with no error explaining it.
+- **Hardcoding aisle commit SHAs.** They go stale in weeks. Derive the sync point each run.
 - **Hand-editing `packages/sanity/src/sanity.types.ts`.** Generated — run `pnpm --filter studio type`.
 - **Hand-writing `textarea.tsx`.** Use the shadcn CLI.
 - **Adding GROQ fragments for product data.** Products come through MCP. `query.ts` changes only for the settings document.
@@ -252,5 +335,8 @@ Run these in order. Step 2 is the one that matters most.
 - **You are about to echo a raw error from `/api/chat` to the client.** The route deliberately does not — raw errors can leak `SANITY_API_READ_TOKEN` or `AI_GATEWAY_API_KEY`.
 - **You are removing the 4MB request cap or the 8-step tool ceiling.** Both exist to bound spend on an endpoint that costs real money per call. Keep them.
 - **The user is about to deploy this publicly.** `/api/chat` is **unauthenticated and consumes paid AI Gateway and MCP resources** — aisle's own source carries this warning. Tell the user plainly, before they deploy, that they need auth and rate limiting first. Do not bury it in a summary.
-- **`pnpm --filter web test` fails after Part B.** You broke the markdown lib. Fix it before continuing; do not proceed and hope.
-- **The project has diverged far from `9eb2555`.** The Part B files have local changes. Reconcile by hand and tell the user which files needed judgement calls.
+- **You are about to copy `seo.ts` or `llms.txt/route.ts` from aisle.** Those diffs are aisle's branding — site title, description, `@akintola4`, aisle keywords. Porting them silently replaces the user's site identity. **This is the most damaging mistake available in this skill.** Verified in a real dry run.
+- **You are copying a shared file wholesale without reading its diff.** Classify every hunk first: AI layer, aisle branding, or unrelated upstream work. Only the first gets ported.
+- **`pnpm build` fails with no AI env vars set.** The variables were made required. Fix that before anything else — it breaks every user who ports but doesn't configure.
+- **`pnpm --filter web test` fails.** Nothing in this port should touch tested code. If tests break, you edited something you shouldn't have.
+- **The project has diverged from aisle's sync point.** The shared files have local changes. Reconcile by hand and tell the user which files needed judgement calls.

--- a/.claude/skills/enable-ai-assistant/SKILL.md
+++ b/.claude/skills/enable-ai-assistant/SKILL.md
@@ -153,9 +153,11 @@ Then `pnpm install`.
 
 Ordering is not cosmetic — `PageContextTracker` needs `QueryClientProvider`, `AiCartBridge` needs `CartProvider`, and `ChatWidget` queries Sanity through react-query. All three are supplied by `Providers`. Mounting them outside it throws at runtime.
 
-Also offset the existing `<Toaster>` so it doesn't sit under the fixed chat launcher — aisle uses `bottom: 5.5rem, right: 1rem`.
-
 If the user chose the feature flag, wrap all three in the `env.NEXT_PUBLIC_ENABLE_AI_ASSISTANT` check.
+
+Also offset the existing `<Toaster>` so it doesn't sit under the fixed chat launcher. Aisle uses `bottom: 5.5rem, right: 1rem`.
+
+**Make that offset conditional on the same flag.** Aisle has no flag, so its offset is unconditional and porting it verbatim leaves toasts floating above an empty corner whenever the assistant is off. Tie the offset to the flag, not to the port.
 
 **2. `packages/sanity/src/query.ts`** — add the `aiAssistantSettings` fetch (~8 lines). This is the *only* GROQ the assistant needs. Do not add product fragments for it; product data comes through MCP.
 
@@ -230,8 +232,17 @@ pnpm --filter web test
 
 | Symptom | Real cause |
 |---|---|
-| `SchemaExtractionError: Failed to load configuration file .../sanity.config.ts` | `@sanity/agent-context` not installed. The config imports `agentContextPlugin` and throws on load. Nothing in the message says so |
 | `Cannot find module 'ai'` in `api/chat/route.ts` | `ai` / `@ai-sdk/*` are deps of `packages/ai-commerce`, not `apps/web`. pnpm won't hoist them |
+
+### `SchemaExtractionError: Failed to load configuration file`
+
+**This message masks its cause and has at least three.** Do not assume the first one. Bisect: stash the entire port and re-run `pnpm --filter studio type` on clean `HEAD`. If it still fails, the cause is pre-existing and nothing to do with this skill.
+
+1. **`@sanity/agent-context` not installed** — the config imports `agentContextPlugin` and throws on load.
+2. **A transitive import that will not resolve under CJS.** Seen in the wild: `apps/studio/components/icon-preview.tsx` imports `lucide-react/dynamic`, and lucide-react 0.562.0 ships `dynamic.mjs` with no `exports` field, so Node's legacy CJS resolver only tries `.js`/`.json`/`.node`. Vite resolves it fine, so dev and build never surface it. Fixing it needs the `.mjs` specifier **and** a `declare module` shim, because `.mjs` alone breaks `tsc` with `TS7016: Could not find a declaration file`.
+3. **Missing env files.** With the above cleared, extraction next fails on `SANITY_STUDIO_PRESENTATION_URL must be set in production environment`, then `CorsOriginError` if you pass a placeholder project ID. `apps/studio/.env.local` and `apps/web/.env.local` must both exist with real values before typegen will run.
+
+Do not read `roboto-shopify.sanity.studio` in the CLI output as proof the Studio is deployed. That is `getStudioHost()`'s fallback for an empty project ID.
 
 `ai-commerce` will also fail `check-types` with *"`@workspace/sanity/types` has no exported member `QueryAiAssistantSettingsResult`"* until typegen has run. That one is ordering, not a missing dep — run typegen first and it resolves.
 
@@ -266,18 +277,16 @@ Needs a Sanity account with `sanity.project/deployStudio` permission. If this fa
 
 **2. Create the Agent Context document**
 
-Fastest path — the seed script added in Part B:
+**This step is manual. There is no script for it.**
 
-```bash
-pnpm --filter studio seed:ai-assistant
-```
+`pnpm --filter studio seed:ai-assistant` seeds the `aiAssistantSettings` singleton, which holds the widget's welcome copy and suggested prompts. That is a **different document** and it does not produce an MCP URL. Run it if you want the welcome state populated, but it is not a substitute for this step.
 
-Or by hand, in the deployed Studio (`https://<hostname>.sanity.studio`):
-1. **Agent Context → + Create new**
+In the deployed Studio (`https://<hostname>.sanity.studio`):
+1. **AI Assistant → Agent Context → + Create new**
 2. Enter a name, a slug (e.g. `shop-assistant`), and instructions for the assistant
 3. **Publish** — an unpublished document will not resolve
 
-Either way, confirm with the user what instructions the assistant should carry. They shape its tone and what it will and won't answer, and are worth getting right rather than defaulting.
+Confirm with the user what instructions the assistant should carry. They shape its tone and what it will and won't answer, and are worth getting right rather than defaulting.
 
 **3. Copy the MCP URL**
 
@@ -340,3 +349,5 @@ Run these in order. Step 2 is the one that matters most.
 - **`pnpm build` fails with no AI env vars set.** The variables were made required. Fix that before anything else — it breaks every user who ports but doesn't configure.
 - **`pnpm --filter web test` fails.** Nothing in this port should touch tested code. If tests break, you edited something you shouldn't have.
 - **The project has diverged from aisle's sync point.** The shared files have local changes. Reconcile by hand and tell the user which files needed judgement calls.
+- **You are about to blame this port for a build failure without bisecting.** Stash the whole port and re-run the failing command on clean `HEAD` first. A masked error like `Failed to load configuration file` may be pre-existing and have nothing to do with the assistant. Check the lockfile too, to rule out an install having bumped a version.
+- **You are porting a layout tweak that assumes the assistant is always on.** Aisle has no feature flag, so anything positional it does (the `Toaster` offset, spacing around the launcher) is unconditional. Under a flag, tie it to the flag.

--- a/.claude/skills/enable-ai-assistant/SKILL.md
+++ b/.claude/skills/enable-ai-assistant/SKILL.md
@@ -198,9 +198,20 @@ SANITY_CONTEXT_MCP_URL: z.string().default(""),
 
 Optional is load-bearing: `/api/chat` returns 503 until both are set, so an unconfigured project still installs, typechecks and builds. Making them required breaks the build for everyone who ports but doesn't configure.
 
-If the user chose the flag, add `NEXT_PUBLIC_ENABLE_AI_ASSISTANT` to `packages/env/src/client.ts` — remembering the `experimental__runtimeEnv` entry, which client vars require and server vars don't.
+If the user chose the flag, add `NEXT_PUBLIC_ENABLE_AI_ASSISTANT` to `packages/env/src/client.ts`:
 
-**6. `turbo.json`** — add both variables to `globalEnv`.
+```ts
+NEXT_PUBLIC_ENABLE_AI_ASSISTANT: z
+  .enum(["true", "false", ""])
+  .default("false")
+  .transform((value) => value === "true"),
+```
+
+Two details that both bite:
+- Client vars need an `experimental__runtimeEnv` entry. Server vars don't. Omitting it means the value is always `undefined` at runtime.
+- The `""` member is deliberate. Without it a bare `NEXT_PUBLIC_ENABLE_AI_ASSISTANT=` line in an env file fails the build.
+
+**6. `turbo.json`** — add all three to `globalEnv`: `AI_GATEWAY_API_KEY`, `SANITY_CONTEXT_MCP_URL`, and the flag if used.
 
 **7. `apps/web/.env.example`** — document them, including that the gateway key is local-dev-only because Vercel uses OIDC.
 
@@ -240,7 +251,7 @@ pnpm --filter web test
 
 1. **`@sanity/agent-context` not installed** — the config imports `agentContextPlugin` and throws on load.
 2. **A transitive import that will not resolve under CJS.** Seen in the wild: `apps/studio/components/icon-preview.tsx` imports `lucide-react/dynamic`, and lucide-react 0.562.0 ships `dynamic.mjs` with no `exports` field, so Node's legacy CJS resolver only tries `.js`/`.json`/`.node`. Vite resolves it fine, so dev and build never surface it. Fixing it needs the `.mjs` specifier **and** a `declare module` shim, because `.mjs` alone breaks `tsc` with `TS7016: Could not find a declaration file`.
-3. **Missing env files.** With the above cleared, extraction next fails on `SANITY_STUDIO_PRESENTATION_URL must be set in production environment`, then `CorsOriginError` if you pass a placeholder project ID. `apps/studio/.env.local` and `apps/web/.env.local` must both exist with real values before typegen will run.
+3. **Missing env files.** With the above cleared, extraction next fails on `SANITY_STUDIO_PRESENTATION_URL must be set in production environment`, then `CorsOriginError` once a placeholder project ID is supplied — schema extraction contacts the Sanity API to validate the project. Both `apps/studio` and `apps/web` need a real env file before typegen will run. A fresh clone has only `.env.example`.
 
 Do not read `roboto-shopify.sanity.studio` in the CLI output as proof the Studio is deployed. That is `getStudioHost()`'s fallback for an empty project ID.
 
@@ -288,6 +299,17 @@ In the deployed Studio (`https://<hostname>.sanity.studio`):
 
 Confirm with the user what instructions the assistant should carry. They shape its tone and what it will and won't answer, and are worth getting right rather than defaulting.
 
+**2b. Create and publish `aiAssistantSettings` too.** Separate document, separate failure. Studio → **AI Assistant → Welcome & Suggestions**, or run `pnpm --filter studio seed:ai-assistant`. Either way it must be **published** — left as a draft, the chat opens with a bare welcome panel and no suggested prompts, which reads like a broken widget rather than missing content.
+
+Verify both exist and neither is a draft (a `drafts.` prefix on `_id` means unpublished):
+
+```groq
+{
+  "agentContexts": *[_type == "sanity.agentContext"]{_id, name, "slug": slug.current},
+  "settings": *[_id == "aiAssistantSettings"][0]
+}
+```
+
 **3. Copy the MCP URL**
 
 ```
@@ -296,14 +318,20 @@ https://api.sanity.io/v2026-04-30/agent-context/<projectId>/<dataset>/<slug>
 
 **4. Get an AI Gateway key** from https://vercel.com/dashboard/ai-gateway.
 
-**5. Write both into `apps/web/.env.local`**
+**5. Write both into the web app's env file**
 
 ```bash
 SANITY_CONTEXT_MCP_URL=https://api.sanity.io/v2026-04-30/agent-context/<projectId>/<dataset>/<slug>
 AI_GATEWAY_API_KEY=<key>
 ```
 
-**`.env.local`, not `.env`.** Next.js precedence means `.env` will be shadowed and the user will get a confusing 503. Confirm `.env.local` is gitignored.
+**Use whichever file the project already has, and never create both.** `CLAUDE.md` documents `apps/web/.env` as this repo's convention, and `.env` works fine on its own. The hazard is precedence: Next.js ranks `.env.local` above `.env`, so if values go in `.env` and someone later adds a `.env.local`, the assistant silently 503s with no obvious cause.
+
+Check first with `ls apps/web/.env*`, write to the one that exists, and confirm it is gitignored:
+
+```bash
+git check-ignore -v apps/web/.env apps/studio/.env
+```
 
 ---
 
@@ -327,7 +355,7 @@ Run these in order. Step 2 is the one that matters most.
 - **Mounting the AI components outside `<Providers>`.** Throws at runtime — they need `QueryClientProvider` and `CartProvider`.
 - **Adding a second `QueryClientProvider`.** `apps/web/src/components/providers.tsx` already has one.
 - **Making the env vars required.** Breaks the build for everyone who hasn't set up the assistant. They default to `""`; the route returns 503.
-- **Writing to `.env` instead of `.env.local`.** Next.js precedence silently shadows it.
+- **Creating a second env file.** `.env` and `.env.local` both work; having both means `.env.local` silently wins and the assistant 503s for no visible reason.
 - **Editing the markdown lib at all.** Its delta against a synced aisle is zero. Leave it alone.
 - **Installing dependencies late.** `@sanity/agent-context` and `ai`/`@ai-sdk/*` must land before typegen, or you get two misleading errors. See Part A step 3b.
 - **Skipping the `globals.css` `@source` line.** Tailwind never scans the vendored package and the chat UI renders unstyled, with no error explaining it.

--- a/.claude/skills/enable-ai-assistant/SKILL.md
+++ b/.claude/skills/enable-ai-assistant/SKILL.md
@@ -13,6 +13,8 @@ The assistant reaches Sanity through **MCP (Agent Context)**, which is schema-aw
 
 **Fallback behaviour is the point.** `AI_GATEWAY_API_KEY` and `SANITY_CONTEXT_MCP_URL` both default to an empty string, and `/api/chat` returns 503 until both are set. A project that ports the assistant but never finishes setup must still install, typecheck, build and serve normally. Never make these variables required.
 
+**A third variable is involved but needs no changes.** The MCP client authenticates to Agent Context with `SANITY_API_READ_TOKEN` as a Bearer token — the route passes it straight through to `packages/ai-commerce/src/mcp/`. `turbo-start-shopify` already declares it as required (`z.string().min(1)` in `packages/env/src/server.ts`), so a working project always has one. Leave it exactly as it is. It is worth knowing about for one reason: it sits **outside** the 503 gate, which checks only the gateway credential and the MCP URL. An empty or under-scoped token therefore gets past the gate and fails later as a 401 from MCP, which reads like a bad MCP URL.
+
 ## Source of truth
 
 Aisle periodically resets its base to a `turbo-start-shopify` commit, then re-applies the AI layer on top. **Never hardcode that commit** — it goes stale within weeks. Derive it every run.
@@ -70,7 +72,7 @@ Ask all of these and **wait for the user to answer before proceeding**:
 
 ## Process
 
-```
+```text
 Part A  →  new files          (pure additions, low risk)
 Part B  →  edits to existing  (the risky half — extend, never replace)
 Part C  →  install + typegen
@@ -86,7 +88,7 @@ Pure additions. Nothing here can break existing behaviour.
 
 **1. Vendor the package.** Copy `packages/ai-commerce/` from aisle in full:
 
-```
+```text
 packages/ai-commerce/
   package.json
   tsconfig.json
@@ -97,11 +99,19 @@ packages/ai-commerce/
 
 `src/ui/` is 7 components: `chat-panel`, `chat-widget`, `empty-state`, `message-input`, `message-list`, `product`, `text-part`.
 
-**2. Record the source SHA.** Create `packages/ai-commerce/README.md` stating which aisle commit this was ported from and the date. Without it there is no way to ever diff or update the vendored copy. Get the SHA with:
+Copy its `package.json` as-is. It carries `catalog:` references for `lucide-react` and `zod`, which resolve against the **local** `pnpm-workspace.yaml` catalog — `turbo-start-shopify` has both, so this works. On a variant whose catalog lacks them, `pnpm install` fails with an unhelpful specifier error; add them to the catalog rather than pinning versions in the vendored file.
+
+**2. Record the source SHA.** Create `packages/ai-commerce/README.md` stating which aisle commit this was ported from and the date. Without it there is no way to ever diff or update the vendored copy.
+
+Use the revision you already resolved in "Source of truth" — the clone at `/tmp/aisle-src` is what you copied from:
 
 ```bash
-curl -s https://api.github.com/repos/robotostudio/turbo-start-aisle/commits/main | grep '"sha"' | head -1
+git -C /tmp/aisle-src rev-parse HEAD
 ```
+
+**Do not re-fetch `main` separately.** It can have moved since the clone, which would record a SHA whose contents you never copied — the one thing this README exists to prevent.
+
+If the sync commit could not be found in the shallow log, deepen it (`git -C /tmp/aisle-src fetch --deepen 50`) and look again. If it still cannot be resolved, **stop and tell the user** rather than falling back to whatever `main` points at.
 
 **3. Add the `textarea` primitive.** It is the one shadcn component `packages/ui` lacks and `src/ui/message-input.tsx` needs:
 
@@ -140,7 +150,7 @@ Then `pnpm install`.
 | `apps/web/src/components/page-context-tracker.tsx` | Keeps the chat aware of the current route |
 | `apps/web/src/components/ai-cart-bridge.tsx` | Bridges chat "add to cart" into `CartProvider` |
 | `apps/studio/schemaTypes/documents/ai-assistant-settings.ts` | Agent Context settings document |
-| `apps/studio/scripts/seed-ai-assistant.ts` | Creates the Agent Context document programmatically — saves the user doing it by hand in Part D |
+| `apps/studio/scripts/seed-ai-assistant.ts` | Seeds the `aiAssistantSettings` singleton — welcome copy and suggested prompts. It does **not** create the Agent Context document; Part D step 2 is manual |
 
 ---
 
@@ -261,7 +271,22 @@ cd apps/studio && pnpm exec tsx -e 'import("./sanity.config.ts").catch(e => cons
 1. **`@sanity/agent-context` not installed** — the config imports `agentContextPlugin` and throws on load. This is the cause this skill actually introduces, and installing the dep before typegen is why step 3b orders it that way.
 2. **Missing env file** — a fresh clone ships only `.env.example`. Extraction reaches the Sanity API to validate the project, so it needs a real `SANITY_STUDIO_PROJECT_ID`; the failure reads `Configuration must contain projectId`, and a placeholder ID gives `CorsOriginError`. Both `apps/studio` and `apps/web` need a real env file. Either `.env` or `.env.local` works.
 
-If unmasking points at neither, bisect: stash the entire port and re-run `pnpm --filter studio type` on clean `HEAD`. If it still fails, the cause is pre-existing and has nothing to do with this skill.
+If unmasking points at neither, bisect against a genuinely clean `HEAD`. **`git stash` alone is not enough** — most of this port is untracked (`packages/ai-commerce/`, the new routes and components), so a plain stash leaves it all in place and the bisect proves nothing.
+
+Use a throwaway worktree, which cannot disturb the work in progress:
+
+```bash
+git worktree add /tmp/bisect-head HEAD
+cd /tmp/bisect-head && pnpm install && pnpm --filter studio type
+```
+
+Or stash including untracked files, if you prefer to stay in place:
+
+```bash
+git stash push -u -m "ai-assistant port"
+```
+
+Either way, if it still fails the cause is pre-existing and has nothing to do with this skill. Remember to `git worktree remove /tmp/bisect-head` or `git stash pop` afterwards — and check `git stash list` first, since the index shifts if other stashes exist.
 
 **Do not blame module resolution without evidence.** `require.resolve("lucide-react/dynamic")` does fail — lucide-react 0.562.0 ships no `exports` map — and that looks like a convincing cause. It is not one: the Sanity CLI does not resolve the config through CJS `require`, and typegen passes without any `.mjs` specifier on Node 24 and Node 26. We chased this once and shipped a fix for it before finding the env cause underneath.
 
@@ -279,9 +304,11 @@ All four must pass before Part D.
 pnpm build     # with NO AI env vars set
 ```
 
-It must succeed, and the site must serve normally. A user who ports the assistant and never configures it must not end up with a broken project. If this fails, the env vars were made required — go back to Part B step 5.
+It must succeed, and the site must serve normally. A user who ports the assistant and never configures it must not end up with a broken project.
 
-Note the widget still *renders* when unconfigured; it just 503s on use. That is aisle's own behaviour and why the feature flag in gating question 4 is worth recommending.
+If it fails, read the error rather than assuming a cause. Required env vars are the likeliest one — check Part B step 5 has both as `.default("")` — but a missing dependency or an unrelated failure produces a failed build too. When the message doesn't clearly name env validation, bisect against a clean `HEAD` using the method above instead of guessing.
+
+Note the widget still *renders* when unconfigured, unless the feature flag is in use; it just 503s on use. That is aisle's own behaviour and why the flag in gating question 4 is worth recommending. Part E step 2 has the full expectations table.
 
 ---
 
@@ -324,7 +351,7 @@ Verify both exist and neither is a draft (a `drafts.` prefix on `_id` means unpu
 
 **3. Copy the MCP URL**
 
-```
+```text
 https://api.sanity.io/v2026-04-30/agent-context/<projectId>/<dataset>/<slug>
 ```
 
@@ -345,6 +372,8 @@ NEXT_PUBLIC_ENABLE_AI_ASSISTANT=true
 
 It defaults to `false`, so skipping this line leaves the widget unmounted no matter how correct everything else is — no bubble, no error, nothing to debug. Setting the keys is not enough on its own.
 
+**Do not add `SANITY_API_READ_TOKEN` here — check it is already set.** The project needs it regardless (it is required in `packages/env/src/server.ts`), and Agent Context uses it as its Bearer token. If the chat returns 401 from MCP while the URL is demonstrably correct, this token is the thing to check: it must have read access to the dataset the Agent Context document lives in.
+
 **Use whichever file the project already has, and never create both.** `CLAUDE.md` documents `apps/web/.env` as this repo's convention, and `.env` works fine on its own. The hazard is precedence: Next.js ranks `.env.local` above `.env`, so if values go in `.env` and someone later adds a `.env.local`, the assistant silently 503s with no obvious cause.
 
 Check first with `ls apps/web/.env*`, write to the one that exists, and confirm it is gitignored:
@@ -360,13 +389,22 @@ git check-ignore -v apps/web/.env apps/studio/.env
 Run these in order. Step 2 is the one that matters most.
 
 1. `pnpm install && pnpm check-types && pnpm lint && pnpm --filter web test` — all clean.
-2. **Negative test — do this before the happy path.** With no AI env vars set (and the flag off, if used): `pnpm build` succeeds and the site serves with no chat bubble. A user who ignores the assistant must not end up with a broken project. If this fails, the env vars were made required — go back to Part B step 7.
+2. **Negative test — do this before the happy path.** With no AI env vars set, `pnpm build` must succeed and the site must serve normally. A user who ignores the assistant must not end up with a broken project.
+
+   What you should see depends on the question-4 answer:
+
+   | Flag | Expected |
+   |---|---|
+   | Not used | The chat bubble **renders**; using it returns 503. This is aisle's own behaviour |
+   | Used, set to `false` | No chat bubble at all, and the `Toaster` sits in its original position |
+
+   If the build fails, read the error before concluding anything. Required env vars are only one cause — go to Part B step 5 and confirm both are `.default("")`. A missing module, a resolution failure or an unrelated error means the cause is elsewhere; use the bisect in Part C instead of assuming.
 3. `pnpm dev` → open http://localhost:3000, click the chat bubble, ask *"show me products under $50"*. Expect real products from the Sanity dataset.
 
    **No bubble at all?** If the flag is in use, check `NEXT_PUBLIC_ENABLE_AI_ASSISTANT=true` is actually in the env file — it defaults to `false`, and an unmounted widget looks identical to a broken port. Also confirm the `experimental__runtimeEnv` entry exists in `packages/env/src/client.ts`; without it the value reads `undefined` at runtime however you set it. Restart `pnpm dev` after either change — `NEXT_PUBLIC_` vars are inlined at build time.
 4. Ask it to filter a collection. Confirm it actually drives `apps/web/src/components/collection/filter-panel.tsx`.
 5. Add to cart from an inline product card. Confirm the line reaches the real Shopify cart, not a local mock.
-6. Visit `/llms.txt` and a `/api/markdown` URL — both were modified in Part B and must still render.
+6. Visit `/llms.txt` and a `/api/markdown` URL. Neither should have been modified — this is a regression check that they still render, and that nothing from aisle leaked into them. If either shows aisle's site title, you ported branding. See the Part B table.
 7. Check https://vercel.com/dashboard/ai-gateway → Logs for the request. To test failover, set a bogus primary model and confirm it falls through.
 8. Confirm `packages/ai-commerce/README.md` records the aisle SHA.
 
@@ -392,7 +430,7 @@ Run these in order. Step 2 is the one that matters most.
 
 ## Red Flags — STOP If You Notice These
 
-- **You are about to commit `.env.local` or paste a key into source.** Never. Both belong in `.env.local` only.
+- **You are about to commit an env file or paste a key into source.** Never. Credentials go in the project's existing gitignored env file — whichever one it already has — and nowhere else. See Part D step 5.
 - **You are about to echo a raw error from `/api/chat` to the client.** The route deliberately does not — raw errors can leak `SANITY_API_READ_TOKEN` or `AI_GATEWAY_API_KEY`.
 - **You are removing the 4MB request cap or the 8-step tool ceiling.** Both exist to bound spend on an endpoint that costs real money per call. Keep them.
 - **The user is about to deploy this publicly.** `/api/chat` is **unauthenticated and consumes paid AI Gateway and MCP resources** — aisle's own source carries this warning. Tell the user plainly, before they deploy, that they need auth and rate limiting first. Do not bury it in a summary.
@@ -401,5 +439,5 @@ Run these in order. Step 2 is the one that matters most.
 - **`pnpm build` fails with no AI env vars set.** The variables were made required. Fix that before anything else — it breaks every user who ports but doesn't configure.
 - **`pnpm --filter web test` fails.** Nothing in this port should touch tested code. If tests break, you edited something you shouldn't have.
 - **The project has diverged from aisle's sync point.** The shared files have local changes. Reconcile by hand and tell the user which files needed judgement calls.
-- **You are about to blame this port for a build failure without bisecting.** Stash the whole port and re-run the failing command on clean `HEAD` first. A masked error like `Failed to load configuration file` may be pre-existing and have nothing to do with the assistant. Check the lockfile too, to rule out an install having bumped a version.
+- **You are about to blame this port for a build failure without bisecting.** Re-run the failing command against a clean `HEAD` first — in a throwaway worktree, or after `git stash push -u`. A plain `git stash` leaves the untracked half of the port behind and tells you nothing. A masked error like `Failed to load configuration file` may be pre-existing and have nothing to do with the assistant. Check the lockfile too, to rule out an install having bumped a version.
 - **You are porting a layout tweak that assumes the assistant is always on.** Aisle has no feature flag, so anything positional it does (the `Toaster` offset, spacing around the launcher) is unconditional. Under a flag, tie it to the flag.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Never issue cart GraphQL directly; the optimistic-update and conflict-classifica
 
 **Import order** is enforced by Biome's organize-imports assist:
 
-```
+```text
 URL / protocol-prefixed / node:
 external packages
                               ← blank line

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. Shopify + Sanity headless commerce — pnpm monorepo, Turborepo.
+
+Read this before writing code. For task-specific recipes, use the skills in `.claude/skills/`.
+
+## Commands
+
+```bash
+pnpm dev                  # all apps (web :3000, studio :3333)
+pnpm build                # all
+pnpm lint                 # biome lint
+pnpm format               # biome format --write
+pnpm check-types          # tsc --noEmit across all packages
+pnpm --filter web test    # vitest (cart, markdown, shopify/product-card)
+pnpm --filter studio type # schema extract + typegen — run after ANY schema change
+```
+
+`pnpm --filter studio type` regenerates `packages/sanity/src/sanity.types.ts`. Any change to a Sanity schema or a GROQ query needs it, and code depending on the new types will not typecheck until it runs.
+
+## Architecture rules
+
+These are the ones that get written wrong. They are not style preferences — breaking them produces code that fails at runtime or build.
+
+**1. Every Shopify call goes through `storefrontQuery()`**
+
+`apps/web/src/lib/shopify/client.ts`. It returns a discriminated union, not a value:
+
+```ts
+type StorefrontQueryResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; kind: "network" | "graphql" | "unknown" };
+```
+
+Always handle the `ok: false` branch. Never call `storefront.request()` directly — you lose the error classification and logging. The module is `server-only`; it cannot be imported into a client component.
+
+**2. Page builder blocks cannot fetch Shopify**
+
+`apps/web/src/components/pagebuilder.tsx` is a `"use client"` component, so every section under it is client-side. Blocks that need Shopify data get it injected: the page fetches server-side, keys results by block `_key`, and passes them down through `PageBuilderProps`.
+
+Follow the `featuredProducts` precedent — see the `featuredProductsByKey` prop and its doc comment in `pagebuilder.tsx`, and `apps/web/src/components/sections/featured-products.tsx`. Adding a `fetch` to a section component is always wrong.
+
+A block registered in the GROQ fragment but missing from `BLOCK_COMPONENTS` renders `UnknownBlockError`, not nothing. Both registries have to agree.
+
+**3. Cart mutations go through the intent pipeline**
+
+`apps/web/src/lib/cart/` — `intents.ts` (build the intent) → `engine.ts` (pure `applyIntent` / `fold` / `recalcTotals`) → `controller.ts` (`CartController`). Server actions live in `apps/web/src/app/cart/actions.ts`.
+
+Never issue cart GraphQL directly; the optimistic-update and conflict-classification logic lives in the engine and gets bypassed. Cart mutations that change server state must call `invalidateCartCache()` from `apps/web/src/lib/cart/server.ts`.
+
+**4. Generated files are never hand-edited**
+
+`packages/sanity/src/sanity.types.ts` and `apps/studio/schema.json` are generated. Run the typegen command instead.
+
+`packages/sanity/src/sanity.types.ts` is the only copy, exported as `@workspace/sanity/types`. Import types from there.
+
+## Conventions
+
+**Formatting** (Biome 2.3.8, `biome.jsonc` is authoritative) — 80 columns, 2-space indent, LF, double quotes including JSX, semicolons always, `es5` trailing commas.
+
+**Import order** is enforced by Biome's organize-imports assist:
+
+```
+URL / protocol-prefixed / node:
+external packages
+                              ← blank line
+@/… aliases and relative paths
+```
+
+**Lint** — `useConst` and `useTemplate` are errors. `noExplicitAny`, `noConsole`, `useExhaustiveDependencies` and `noExcessiveCognitiveComplexity` are warnings. `noConsole` is off under `**/scripts/**` and `packages/logger/`. Use `Logger` from `@workspace/logger` in app code rather than `console`.
+
+**TypeScript** — strict, `noUncheckedIndexedAccess`, module `NodeNext`, target ES2022. Indexed access returns `T | undefined`; handle it rather than asserting.
+
+**No barrel files.** Import from the module that defines the symbol.
+
+**Path aliases** — `@/*` → `apps/web/src/*`, `@workspace/ui/*` → `packages/ui/src/*`, plus `@workspace/{env,sanity,logger}`.
+
+**Env vars** are validated. Import from `@workspace/env/client` or `@workspace/env/server`, never raw `process.env`. Adding one means editing the zod schema, `experimental__runtimeEnv` (client only), `turbo.json` `globalEnv`, and the relevant `.env.example`.
+
+**UI** — shadcn/ui (new-york) in `packages/ui/src/components/`. Add components with `pnpm dlx shadcn@latest add <name> -c packages/ui`; don't hand-write a primitive that the CLI can generate.
+
+## Data flow
+
+1. GROQ queries are defined with `defineQuery` in `packages/sanity/src/query.ts` — composable fragments for images, links, rich text, and page builder blocks.
+2. `sanityFetch()` from `packages/sanity/src/live.ts` is used in RSC pages, and carries live-preview support.
+3. Product and collection pages fetch Sanity and Shopify **in parallel** — Sanity holds editorial content and drives `generateStaticParams`; Shopify holds live price and inventory. See `apps/web/src/app/products/[handle]/page.tsx`.
+4. Products exist in Sanity as `product` documents whose `store.*` subtree is synced read-only by Sanity Connect for Shopify. Don't write to `store.*`.
+
+## Skills
+
+`.claude/skills/` holds tested playbooks for recurring tasks. Prefer them over improvising:
+
+- `add-pagebuilder-block` — add a block to the Sanity page builder
+- `enable-ai-assistant` — add the turbo-start-aisle AI shopping assistant
+- `generate-thumbnails-agentic` — page builder block thumbnails via Playwright MCP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,24 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) when working in this repository.
+
+**Conventions, architecture rules and data flow live in [`AGENTS.md`](./AGENTS.md).** Read that first — it is the single source for how to write code here, and it is shared with Cursor and Codex. This file covers only what's specific to running the repo.
 
 ## Project Overview
 
 Shopify + Sanity headless commerce starter — pnpm monorepo with Turborepo orchestration.
+
+```
+apps/
+  web/          → Next.js 16 (App Router, Turbopack, React Compiler, RSC)
+  studio/       → Sanity Studio v5 (custom structure, plugins, blueprints)
+packages/
+  env/          → @workspace/env — T3 env validation (Zod v4), client.ts + server.ts
+  sanity/       → @workspace/sanity — Sanity client, GROQ queries, live preview, generated types
+  ui/           → @workspace/ui — Shadcn (new-york style) + Tailwind v4 primitives
+  logger/       → @workspace/logger — Logger class wrapping console.*
+  typescript-config/ → shared tsconfig presets
+```
 
 ## Commands
 
@@ -24,80 +38,51 @@ pnpm lint             # biome lint
 pnpm format           # biome format --write
 pnpm format:check     # biome format (check only)
 pnpm check-types      # tsc --noEmit across all packages
+pnpm --filter web test  # vitest — cart, markdown, shopify/product-card suites
 
-# Studio schema tooling (run from apps/studio)
-npx sanity schema extract --enforce-required-fields
-npx sanity typegen generate
-npx sanity deploy
+# Studio schema tooling
+pnpm --filter studio type      # schema extract + typegen → packages/sanity/src/sanity.types.ts
+pnpm --filter studio extract   # schema extract only
+npx sanity deploy              # from apps/studio
 
-# Seed data (run from apps/studio)
-npx sanity dataset import ./seed-data.tar.gz production --replace
+# Seed data
+pnpm seed:shopify     # faker products → Shopify Admin API (needs SHOPIFY_ADMIN_ACCESS_TOKEN)
+pnpm verify:shopify   # check store state
+npx sanity dataset import ./seed-data.tar.gz production --replace   # from apps/studio
 ```
 
-No test framework is configured.
+Tests are vitest, scoped to `apps/web`, and there is no `test` task in `turbo.json` — run them through the filter above.
 
-## Architecture
+## Skills
 
-```
-apps/
-  web/          → Next.js 16 (App Router, Turbopack, React Compiler, RSC)
-  studio/       → Sanity Studio v5 (custom structure, plugins, blueprints)
-packages/
-  env/          → @workspace/env — T3 env validation (Zod v4), client.ts + server.ts
-  sanity/       → @workspace/sanity — Sanity client, GROQ queries, live preview, generated types
-  ui/           → @workspace/ui — Shadcn (new-york style) + Tailwind v4 primitives
-  logger/       → @workspace/logger — Logger class wrapping console.*
-  typescript-config/ → shared tsconfig presets
-```
+`.claude/skills/` holds tested playbooks. Prefer them over improvising:
 
-### Data Flow
+| Skill | Use for |
+|---|---|
+| `add-pagebuilder-block` | Adding a block to the Sanity page builder |
+| `enable-ai-assistant` | Adding the turbo-start-aisle AI shopping assistant |
+| `generate-thumbnails-agentic` | Page builder block thumbnails via Playwright MCP |
 
-1. **GROQ queries** defined with `defineQuery` in `packages/sanity/src/query.ts` — composable fragments for images, links, rich text, page builder blocks
-2. **`sanityFetch()`** from `packages/sanity/src/live.ts` (via `next-sanity/defineLive`) — used in RSC pages for data fetching with live preview support
-3. **Page Builder** (`apps/web/src/components/pagebuilder.tsx`) — client component mapping `_type` → React section component via `BLOCK_COMPONENTS` record. Uses `useOptimistic` from `@sanity/visual-editing` for live editing
-4. **Section components** in `apps/web/src/components/sections/` — `hero`, `cta`, `faq-accordion`, `feature-cards-with-icon`, `subscribe-newsletter`, `image-link-cards`
-5. **Types** auto-generated: run `pnpm --filter studio type` → outputs to `packages/sanity/src/sanity.types.ts`
+## Sanity Studio
 
-### Adding a New Page Builder Block
+- **Singletons**: `homePage`, `blogIndex`, `collectionsIndex`, `settings`, `footer`, `navbar`
+- **Page builder blocks**: defined in `apps/studio/schemaTypes/blocks/`, registered in `blocks/index.ts` — **that file is the source of truth for which blocks exist**
+- **Shopify objects** (`apps/studio/schemaTypes/objects/shopify/`): synced read-only by Sanity Connect; never write to `store.*`
+- **Blueprint** (`sanity.blueprint.ts`): auto-redirect function creating `redirect` documents on slug change
+- **Structure**: `apps/studio/structure.ts`; presentation URL resolution in `apps/studio/location.ts`
 
-1. Create Sanity schema in `apps/studio/schemaTypes/blocks/`
-2. Register it in `apps/studio/schemaTypes/index.ts`
-3. Add GROQ fragment in `packages/sanity/src/query.ts` and include in `pageBuilderFragment`
-4. Run `pnpm --filter studio type` to regenerate types
-5. Create React component in `apps/web/src/components/sections/`
-6. Register in `BLOCK_COMPONENTS` map in `apps/web/src/components/pagebuilder.tsx`
-7. Add type to `PageBuilderBlockTypes` union in `apps/web/src/types.ts`
+## Other
 
-### Sanity Studio Structure
-
-- **Documents**: `blog`, `page`, `faq`, `author`, `product`, `collection`, `productVariant`, `redirect`, `colorTheme`
-- **Singletons**: `homePage`, `blogIndex`, `settings`, `footer`, `navbar`
-- **Shopify objects**: `shopifyProduct`, `shopifyProductVariant`, `shopifyCollection`, `inventory`, `option`, `priceRange`, etc.
-- **Blueprint** (`sanity.blueprint.ts`): auto-redirect function — creates redirect documents on slug change
-
-### Key Patterns
-
-- **Env validation**: `@workspace/env/client` and `@workspace/env/server` — validated imports, never raw `process.env`
-- **Path aliases**: `@/*` → `apps/web/src/*`, `@workspace/ui/*` → `packages/ui/src/*`
-- **SEO**: `getSEOMetadata()` in `apps/web/src/lib/seo.ts`, OG images via `/api/og` route
-- **Visual editing**: `VisualEditing` from `next-sanity` + `createDataAttribute` per block, draft mode via `/api/presentation-draft`
+- **SEO**: `getSEOMetadata()` in `apps/web/src/lib/seo.ts`, OG images via `/api/og`
+- **AI agent surfaces**: content negotiation serves Markdown to agents (`apps/web/src/proxy.ts`, `app/api/markdown/route.ts`), plus `app/llms.txt/route.ts`
+- **Visual editing**: `VisualEditing` from `next-sanity` + `createDataAttribute` per block; draft mode via `/api/presentation-draft`
 - **Redirects**: fetched from Sanity at Next.js build time via `queryRedirects` in `next.config.ts`
-
-## Tooling
-
-- **Node**: >=22
-- **Package manager**: pnpm 10.28.0 (workspace protocol, catalog for shared versions in `pnpm-workspace.yaml`)
-- **Formatter/Linter**: Biome 2.3.8 — double quotes, semicolons, 2-space indent, 80 char width, trailing commas es5
-- **Import order** (Biome): URL/Node → packages → blank line → aliases/paths
-- **TypeScript**: strict, `noUncheckedIndexedAccess`, module NodeNext, target ES2022
-- **Tailwind CSS v4**: CSS-first config via `@import "tailwindcss"`, OKLCH color tokens, dark mode via `@custom-variant`
-- **React Compiler**: enabled via `babel-plugin-react-compiler` in Next.js config
+- **Node** >=22, **pnpm** 10.28.0 (workspace protocol, catalog in `pnpm-workspace.yaml`)
 
 ## Environment Variables
 
-**Web** (`apps/web/.env`):
-- `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NEXT_PUBLIC_SANITY_DATASET`, `NEXT_PUBLIC_SANITY_API_VERSION`, `NEXT_PUBLIC_SANITY_STUDIO_URL`
-- `SANITY_API_READ_TOKEN`, `SANITY_API_WRITE_TOKEN`
+**Web** (`apps/web/.env`): `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NEXT_PUBLIC_SANITY_DATASET`, `NEXT_PUBLIC_SANITY_API_VERSION`, `NEXT_PUBLIC_SANITY_STUDIO_URL`, `NEXT_PUBLIC_STORE_CURRENCY`, `SANITY_API_READ_TOKEN`, `SANITY_API_WRITE_TOKEN`, `SHOPIFY_STORE_DOMAIN`, `SHOPIFY_STOREFRONT_ACCESS_TOKEN`, `SHOPIFY_API_VERSION`
 
-**Studio** (`apps/studio/.env`):
-- `SANITY_STUDIO_PROJECT_ID`, `SANITY_STUDIO_DATASET`, `SANITY_STUDIO_TITLE`, `SANITY_STUDIO_PRESENTATION_URL`
+**Studio** (`apps/studio/.env`): `SANITY_STUDIO_PROJECT_ID`, `SANITY_STUDIO_DATASET`, `SANITY_STUDIO_TITLE`, `SANITY_STUDIO_PRESENTATION_URL`, `SHOPIFY_ADMIN_ACCESS_TOKEN` (seed scripts only)
+
+Validated via `@workspace/env` — see AGENTS.md for the four places a new variable must be registered.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guidance for Claude Code (claude.ai/code) when working in this repository.
 
 Shopify + Sanity headless commerce starter — pnpm monorepo with Turborepo orchestration.
 
-```
+```text
 apps/
   web/          → Next.js 16 (App Router, Turbopack, React Compiler, RSC)
   studio/       → Sanity Studio v5 (custom structure, plugins, blueprints)
@@ -41,14 +41,14 @@ pnpm check-types      # tsc --noEmit across all packages
 pnpm --filter web test  # vitest — cart, markdown, shopify/product-card suites
 
 # Studio schema tooling
-pnpm --filter studio type      # schema extract + typegen → packages/sanity/src/sanity.types.ts
-pnpm --filter studio extract   # schema extract only
-npx sanity deploy              # from apps/studio
+pnpm --filter studio type          # schema extract + typegen → packages/sanity/src/sanity.types.ts
+pnpm --filter studio extract       # schema extract only
+pnpm --filter studio run deploy    # publish the Studio
 
 # Seed data
 pnpm seed:shopify     # faker products → Shopify Admin API (needs SHOPIFY_ADMIN_ACCESS_TOKEN)
 pnpm verify:shopify   # check store state
-npx sanity dataset import ./seed-data.tar.gz production --replace   # from apps/studio
+pnpm --filter studio exec sanity dataset import ./seed-data.tar.gz production --replace
 ```
 
 Tests are vitest, scoped to `apps/web`, and there is no `test` task in `turbo.json` — run them through the filter above.
@@ -66,7 +66,7 @@ Tests are vitest, scoped to `apps/web`, and there is no `test` task in `turbo.js
 ## Sanity Studio
 
 - **Singletons**: `homePage`, `blogIndex`, `collectionsIndex`, `settings`, `footer`, `navbar`
-- **Page builder blocks**: defined in `apps/studio/schemaTypes/blocks/`, registered in `blocks/index.ts` — **that file is the source of truth for which blocks exist**
+- **Page builder blocks**: defined in `apps/studio/schemaTypes/blocks/`, registered in `blocks/index.ts` — **the Studio-side registry, and the list to read before assuming which blocks exist**. Rendering needs two more registrations to agree: the GROQ fragment in `packages/sanity/src/query.ts` and `BLOCK_COMPONENTS` in `apps/web/src/components/pagebuilder.tsx`. A block present in one but not the others fails distinctly — see the `add-pagebuilder-block` skill
 - **Shopify objects** (`apps/studio/schemaTypes/objects/shopify/`): synced read-only by Sanity Connect; never write to `store.*`
 - **Blueprint** (`sanity.blueprint.ts`): auto-redirect function creating `redirect` documents on slug change
 - **Structure**: `apps/studio/structure.ts`; presentation URL resolution in `apps/studio/location.ts`
@@ -85,4 +85,6 @@ Tests are vitest, scoped to `apps/web`, and there is no `test` task in `turbo.js
 
 **Studio** (`apps/studio/.env`): `SANITY_STUDIO_PROJECT_ID`, `SANITY_STUDIO_DATASET`, `SANITY_STUDIO_TITLE`, `SANITY_STUDIO_PRESENTATION_URL`, `SHOPIFY_ADMIN_ACCESS_TOKEN` (seed scripts only)
 
-Validated via `@workspace/env` — see AGENTS.md for the four places a new variable must be registered.
+**Web** variables are validated via `@workspace/env` — see AGENTS.md for the four places a new variable must be registered.
+
+**Studio variables are not.** `apps/studio` reads `process.env` directly in `sanity.cli.ts`, `utils/helper.ts` and the scripts, with no schema and no startup check. A missing one surfaces late and badly: an unset `SANITY_STUDIO_PRESENTATION_URL` used to fail `sanity schema extract` with `Failed to load configuration file`, naming nothing. Add guards at the point of use, and give them a message that says which variable is missing.


### PR DESCRIPTION
Adds `AGENTS.md` and two skills under `.claude/skills/`.

`add-pagebuilder-block` covers the block recipe: schema, GROQ fragment, section component, both registries, typegen.

`enable-ai-assistant` ports the shopping assistant from turbo-start-aisle.

`AGENTS.md` holds the conventions and the architecture rules agents get wrong. Cursor and Codex read it, they do not read `CLAUDE.md`. `CLAUDE.md` now points at it instead of repeating it, and two stale claims are fixed (it said no test framework was configured, and listed 6 of the 12 blocks).

## Dry runs

Both skills were run before landing, not just written.

`add-pagebuilder-block` built a throwaway `quoteBanner` block end to end. Three wrong claims found and fixed: the typegen idempotency check did not say what to diff against, the shared GROQ fragments hardcode their field names (`imageFragment` only matches a field called `image`), and Part C read as optional when a block without a thumbnail shows a blank tile in the Studio picker.

`enable-ai-assistant` was ported into a throwaway worktree and verified live against the real catalog. Seven wrong claims found and fixed. Two would have caused damage: the skill told the agent to port `seo.ts` and `llms.txt/route.ts` as assistant metadata, but those diffs are aisle branding (title, description, Twitter handle, keywords), so following it would have replaced this site identity with aisle. It also described `lib/markdown/*` as the highest risk edit in the port when the real delta is zero lines.

The rewritten skill now derives aisle sync commit each run instead of hardcoding SHAs, and classifies every diff as AI layer, aisle branding, or unrelated upstream work before porting anything.

## Verified

Port applied cleanly in the worktree: typegen, `check-types`, `lint`, 112 tests, and `pnpm build` with no AI env vars all pass. Live chat answered a catalog query with correct negative handling, drove collection filters, and added to the real Shopify cart. Zero console errors.


## PREVIEW 

The branding and products here are aisle's, not this repo's. The dry run ran against aisle's Sanity dataset and Shopify store so the port could be confirmed on real data, which is why the storefront reads Turbo Start Aisle and shows aisle's catalog. The skills themselves are content agnostic and nothing in this PR touches either project's data or env.
<img width="3562" height="2738" alt="CleanShot 2026-08-05 at 11 30 24@2x" src="https://github.com/user-attachments/assets/1aa0c8d5-147e-426a-8441-537b4109d1b9" />
<img width="3562" height="2738" alt="CleanShot 2026-08-05 at 11 29 51@2x" src="https://github.com/user-attachments/assets/5aa475e5-4dd1-46f0-96fa-e07b9a13263a" />


No application code changes. Documentation only.

Closes ROB-2510


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating page-builder blocks, including setup, validation, testing, and troubleshooting.
  * Added instructions for enabling the AI shopping assistant, including configuration, integrations, deployment, and security considerations.
  * Added repository guidance for AI coding agents, development conventions, architecture, tooling, and environment variables.
  * Updated contributor documentation with monorepo structure, testing commands, Studio workflows, and available skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->