### PR TITLE
ROB-2522: resolve lucide-react/dynamic under the Sanity CLI

### DIFF
--- a/apps/studio/components/icon-preview.tsx
+++ b/apps/studio/components/icon-preview.tsx
@@ -1,5 +1,8 @@
 import { TriangleAlert } from "lucide-react";
-import { DynamicIcon, type dynamicIconImports } from "lucide-react/dynamic";
+// Explicit .mjs specifier — the bare "lucide-react/dynamic" does not resolve
+// under Node's CJS resolver, which breaks `sanity schema extract` on Node 24.
+// See lucide-dynamic.d.ts for the detail and the removal condition.
+import { DynamicIcon, type dynamicIconImports } from "lucide-react/dynamic.mjs";
 
 export const lucideIconPreview = (icon: keyof typeof dynamicIconImports) => {
   return (

--- a/apps/studio/lucide-dynamic.d.ts
+++ b/apps/studio/lucide-dynamic.d.ts
@@ -1,0 +1,24 @@
+/**
+ * `components/icon-preview.tsx` imports `lucide-react/dynamic.mjs` rather than
+ * `lucide-react/dynamic`.
+ *
+ * lucide-react 0.562.0 ships `dynamic.mjs` and `dynamic.d.ts` with no `exports`
+ * map, so Node's CJS resolver only tries dynamic.js/.json/.node and finds none
+ * of them. Verified directly:
+ *
+ *   require.resolve("lucide-react/dynamic")     → MODULE_NOT_FOUND
+ *   require.resolve("lucide-react/dynamic.mjs") → resolves
+ *
+ * `sanity schema extract` loads the Studio config through that resolver and
+ * fails on Node 24 with a misleading "Failed to load configuration file" error.
+ * It happens to succeed on Node 26, but the bare specifier does not resolve
+ * there either, so do not rely on that.
+ *
+ * TypeScript maps a .mjs specifier to .d.mts and lucide only ships dynamic.d.ts,
+ * so the explicit specifier loses its types without this re-export.
+ *
+ * Remove both once lucide-react publishes an `exports` map.
+ */
+declare module "lucide-react/dynamic.mjs" {
+  export * from "lucide-react/dynamic";
+}


### PR DESCRIPTION
Pre-existing bug, unrelated to any feature work. Found while a teammate was dry-running the `enable-ai-assistant` skill.

## Symptom

```
SchemaExtractionError: Failed to load configuration file
  ".../apps/studio/sanity.config.ts"
```

`pnpm --filter studio type` fails and the message names no cause.

## Cause

`apps/studio/components/icon-preview.tsx` imports `lucide-react/dynamic` for `DynamicIcon`. lucide-react 0.562.0 ships `dynamic.mjs` with no `exports` field, so Node falls back to legacy CJS resolution, which only tries `.js`, `.json`, `.node` and `dynamic/index.js`. None exist.

```
require.resolve("lucide-react/dynamic")     -> MODULE_NOT_FOUND
require.resolve("lucide-react/dynamic.mjs") -> resolves
```

The Sanity CLI config loader uses that resolver. Vite does not, which is why `pnpm dev:studio` and `sanity build` never surfaced it.

Confirmed pre-existing by bisect: stashing the in-progress branch entirely and re-running extraction on clean `HEAD` failed identically. The lockfile resolves 0.562.0 for studio at `HEAD` too, ruling out an install having bumped the version.

## Fix

Explicit `.mjs` specifier, plus a `declare module` shim re-pointing the types at `dynamic.d.ts`.

The specifier alone is not enough — it fixes resolution but breaks `tsc`:

```
error TS7016: Could not find a declaration file for module "lucide-react/dynamic.mjs"
```

TypeScript maps a `.mjs` specifier to `.d.mts`, and lucide only ships `dynamic.d.ts`. Both changes are needed. Remove them once lucide-react publishes an `exports` map.

`apps/web/src/components/elements/sanity-icon.tsx` deliberately keeps the bare specifier. Turbopack resolves it and the Sanity CLI never loads that file.

## Verification

`pnpm --filter studio type`, `check-types` and `lint` all pass. On the machine where it reproduced: config loads, `tsc` clean.

## Reproduction note

The bug does not surface on every machine. Typegen passes on mine with and without this change, on Node 24 and Node 26.

That is a fact about the bug, not the fix. `require.resolve` fails identically everywhere, so the explicit specifier is correct in both cases and a no-op where the bare one happens to work.

## If you hit that error later

It has at least three causes and names none of them: a missing `@sanity/agent-context`, this resolution failure, and missing env files all produce the same line. Unmask it before diagnosing:

```bash
pnpm exec tsx -e 'import("./sanity.config.ts").catch(e => console.log(e.message))'
```

Closes ROB-2522
