### PR TITLE
ROB-2522: let schema extraction run without a studio env file

### DIFF
--- a/apps/studio/utils/helper.ts
+++ b/apps/studio/utils/helper.ts
@@ -163,12 +163,19 @@ export function createPageTemplate() {
 
 /**
  * Determines the presentation URL based on the current environment.
- * Uses localhost:3000 for development.
+ * Uses localhost:3000 everywhere except production.
  * In production, requires SANITY_STUDIO_PRESENTATION_URL to be set.
+ *
+ * The check is `!== "production"` rather than `=== "development"` because the
+ * Sanity CLI runs the config with NODE_ENV unset. Under the stricter check,
+ * `sanity schema extract` fell through to the throw below and failed on any
+ * checkout without an env file — reported as an unhelpful
+ * "Failed to load configuration file".
+ *
  * @throws {Error} If SANITY_STUDIO_PRESENTATION_URL is not set in production
  */
 export const getPresentationUrl = () => {
-  if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV !== "production") {
     return "http://localhost:3000";
   }
 


### PR DESCRIPTION
Fresh clone, `pnpm install`, `pnpm --filter studio type` — fails with:

```
SchemaExtractionError: Failed to load configuration file ".../apps/studio/sanity.config.ts"
```

## Cause

`getPresentationUrl()` guarded on `NODE_ENV === "development"`. I probed the value inside `sanity.config.ts` during extraction: it is **`undefined`**, not `"development"`. So the dev branch never matched, execution fell through to the production throw, and a guard meant for deploys fired during ordinary local codegen.

Guarding on `!== "production"` instead. Verified across all three cases with the URL unset:

| `NODE_ENV` | Before | After |
|---|---|---|
| `"production"` | throws | throws |
| `"development"` | localhost | localhost |
| unset (the CLI) | **throws** | localhost |

The production guard is unchanged.

## This does not remove the env requirement

An env file is still needed for typegen to finish. What changes is the error: `Configuration must contain projectId` instead of a message that names nothing. Either `.env` or `.env.local` works.

## Correction to #62

#62 landed a `.mjs` specifier for `lucide-react/dynamic` on the theory that CJS resolution was breaking extraction. With env working I could finally test that properly: typegen passes **without** it on Node 24.19.0 and Node 26.5.0.

`require.resolve("lucide-react/dynamic")` genuinely does fail, which is what made the theory convincing — but the Sanity CLI does not resolve the config through CJS `require`, so it never mattered on this path. That change is harmless and stays; it just was not the bug. The tester most likely fixed their env in the same sitting and we credited the wrong change.

Closes ROB-2522